### PR TITLE
Update Box

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -873,8 +873,8 @@ apps:
       client_id: "yCKLKXrrkigZwoQ9d6xzmE5NuvVW0oBj"
       op: auth0
       vanity_url: ['/box']
-      url: "https://auth.mozilla.auth0.com/samlp/yCKLKXrrkigZwoQ9d6xzmE5NuvVW0oBj"
+      url: "https://auth.mozilla.auth0.com/samlp/Jd8q8egYqsQHQ16dfwwyVjSXJPKioiZ4"
       logo: "auth0.png"
       authorized_users: []
       authorized_groups: ['mozilliansorg_nda', 'team_moco', 'team_mofo']
-      display: true
+      display: false


### PR DESCRIPTION
Wrong SAML initiated login URL, would fail with box. 
Removed app display as it need per-account whitelisting on the box side, so many users wouldnt be able to use it but still see the icon