### PR TITLE
adding IAM infra Grafana

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -927,6 +927,16 @@ apps:
       authorized_groups: ['mozilliansorg_mozilla-iam-aws-access']
       display: false
   - application:
+      name: "IAM Grafana"
+      client_id: "qIOeGmYddK11UwsB9L3cpuYQ1RdAuQkn"
+      vanity_url: ['/iam-grafana']
+      op: auth0
+      url: "https://auth.mozilla.auth0.com/samlp/qIOeGmYddK11UwsB9L3cpuYQ1RdAuQkn"
+      logo: "auth0.png"
+      authorized_users: []
+      authorized_groups: ['mozilliansorg_mozilla-iam-aws-access']
+      display: false
+  - application:
       name: "Box"
       client_id: "yCKLKXrrkigZwoQ9d6xzmE5NuvVW0oBj"
       op: auth0

--- a/apps.yml
+++ b/apps.yml
@@ -931,7 +931,7 @@ apps:
       client_id: "qIOeGmYddK11UwsB9L3cpuYQ1RdAuQkn"
       vanity_url: ['/iam-grafana']
       op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/qIOeGmYddK11UwsB9L3cpuYQ1RdAuQkn"
+      url: "https://grafana.infra.iam.mozilla.com/login/generic_oauth"
       logo: "auth0.png"
       authorized_users: []
       authorized_groups: ['mozilliansorg_mozilla-iam-aws-access']


### PR DESCRIPTION
This adds a new application for Grafana. It is currently pointing at Auth0 dev until we test this. When it is working as intended, I can ask for a prod app and I can update the client ID.