### PR TITLE
setting proper OIDC client ID for Grafana

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -928,7 +928,7 @@ apps:
       display: false
   - application:
       name: "IAM Grafana"
-      client_id: "qIOeGmYddK11UwsB9L3cpuYQ1RdAuQkn"
+      client_id: "nlE73wPPuOaN0wAYKWY6QD3VcjUStehZ"
       vanity_url: ['/iam-grafana']
       op: auth0
       url: "https://grafana.infra.iam.mozilla.com/login/generic_oauth"


### PR DESCRIPTION
This is a follow up to #204. This PR provides the correct client ID.