### PR TITLE
 Support for deracheting/AAL

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -1479,7 +1479,8 @@ apps:
     - /navex
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: 1tAZ7tyiARXodCaLoy38jYmzKLqjyDX8
     display: false
@@ -1489,7 +1490,8 @@ apps:
     url: https://confluence.mozilla-community.org/plugins/servlet/samlsso
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: 7RvvmjstmMm93e1eVimyRElqv8vjrEJC
     display: false
@@ -1499,7 +1501,8 @@ apps:
     url: https://wpengine.mcws.mozilla.community/
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: 7wyIItkJX4t7vYEaDmGrwP9k2fBh5qWP
     display: false
@@ -1509,7 +1512,8 @@ apps:
     url: https://prod.testrp.security.allizom.org/redirect_uri
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: 8J731AkHnZXviXJWzM2kdQTENMJMSVNI
     display: false
@@ -1519,7 +1523,8 @@ apps:
     url: https://jenkins.services.mozilla.community/redirect_uri
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: 8fsFs05sqRr0Gt3RGm4Jh0AYNyByjXKt
     display: false
@@ -1529,7 +1534,8 @@ apps:
     url: https://mon.admin.us-west-2.nubis-gozer.nubis.allizom.org/redirect
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: 9D6nm17QufE7lvipnl8l7sVHWCaElnrL
     display: false
@@ -1539,7 +1545,8 @@ apps:
     url: https://standupdev.herokuapp.com/
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: 9LGw821wb6hHd30HZWMy3eBE3JMtuDLs
     display: false
@@ -1549,7 +1556,8 @@ apps:
     url: http://localhost:5050/login
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: 9sl5SW42wjikqzf9DXZSxzD8BHPf456e
     display: false
@@ -1559,7 +1567,8 @@ apps:
     url: https://air-dev.allizom.org/oidc/callback/
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: CPnG4kKY6vWH39q2adBEyxFRAE0lO7bm
     display: false
@@ -1569,7 +1578,8 @@ apps:
     url: http://localhost:8080/oidc/callback
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: CeA3IcqB1hc2Sbsxmtm909rbeInXv69s
     display: false
@@ -1579,7 +1589,8 @@ apps:
     url: https://sso.admin.us-west-2.nubis-jd.nubis.allizom.org/sso
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: CtXC7ukVJO7T3kfAwdvHLjxiV0eLFTaZ
     display: false
@@ -1589,7 +1600,8 @@ apps:
     url: https://sso.admin.us-west-2.nubis-training.nubis.allizom.org/sso
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: DVvwftNuKq4miIQ0HDy7YqlkfilCAuLp
     display: false
@@ -1599,7 +1611,8 @@ apps:
     url: http://localhost:8000/oidc/callback/
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: FQw134gwheaK3KkW6fQf0JPV6P7h2yo1
     display: false
@@ -1609,7 +1622,8 @@ apps:
     url: https://web-mozillians.dinopark.infra.iam.mozilla.com/oidc/callback/
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: Hg3vUmTAlI2sFXR6Z4cy0Lm1hgKRapf6
     display: false
@@ -1619,7 +1633,8 @@ apps:
     url: https://pulseguardian.mozilla.org/auth/callback
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: I2T4dYNc0dj2u1C8qbddYipgnpVtEd1K
     display: false
@@ -1629,7 +1644,8 @@ apps:
     url: https://sso.stage.us-west-2.nubis-gozer.nubis.allizom.org/sso
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: M9OoQEQVR0M1qtyGvPql3ZDi4T7XMQEA
     display: false
@@ -1639,7 +1655,8 @@ apps:
     url: https://tools.taskcluster.net/login/auth0
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: NI6D4Rk4QCZIlLOBKmTtPvrz5CyMBm23
     display: false
@@ -1649,7 +1666,8 @@ apps:
     url: https://web-remo-staging.production.paas.mozilla.community/oidc/callback/
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: OwbZj5f5NnK161LTtOVshM131Nf6jWBe
     display: false
@@ -1659,7 +1677,8 @@ apps:
     url: https://respond.mozilla.community/oidc/callback/
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: Qp7DIxm4B16jnTcXsR6fai1X0a8GWVBZ
     display: false
@@ -1669,7 +1688,8 @@ apps:
     url: https://mon.prod.us-west-2.nubis-gozer.nubis.allizom.org/redirect
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: RaxnXTpQY5WyVVw6I2mSLblbljiGH8B2
     display: false
@@ -1679,7 +1699,8 @@ apps:
     url: https://moderator.mozilla.org/oidc/callback/
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: SSG7PVY70x785oW1noHJZi1Ck2wzdlyM
     display: false
@@ -1689,7 +1710,8 @@ apps:
     url: https://taskcluster-tools.ngrok.io/oidc-login
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: StXJySdOLGiWbnnmUGTC5zRGDymFSBO1
     display: false
@@ -1699,7 +1721,8 @@ apps:
     url: http://127.0.0.1:8000/oidc/callback/
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: Tpd4uL15gBCjbypCYERVffaCuDx7hFPc
     display: false
@@ -1709,7 +1732,8 @@ apps:
     url: http://localhost:3000/auth/auth0/callback
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: U4mXW5E6cfBqLziVewwkxApHGFNPA2pI
     display: false
@@ -1719,7 +1743,8 @@ apps:
     url: https://jira.mozilla-community.org/plugins/servlet/samlsso
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: UCOY390lYDxgj5rU8EeXRtN6EP005k7V
     display: false
@@ -1729,7 +1754,8 @@ apps:
     url: https://sso.mozilla.com/redirect_uri
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: YwL6bJ8mXFiCplWbMLaX2fqu715rKP8u
     display: false
@@ -1739,7 +1765,8 @@ apps:
     url: https://voice.mozilla.org/callback
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: ZShocyal5HnbTYs7CH0rwytjTJGMFsav
     display: false
@@ -1749,7 +1776,8 @@ apps:
     url: https://dinopark.k8s.dev.sso.allizom.org/redirect_uri
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: aDL5o9SZRaYTH5zzkGntT4l76qydMbZe
     display: false
@@ -1759,7 +1787,8 @@ apps:
     url: http://localhost:5000/redirect_uri
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: aJc4zjynRegTcrrxjB7PqV8lb9FdAVBr
     display: false
@@ -1769,7 +1798,8 @@ apps:
     url: https://discourse-staging.production.paas.mozilla.community/auth/auth0/callback
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: c4j1TRdnJPdkFGJoEsU5LtL3ltPC5QyU
     display: false
@@ -1779,7 +1809,8 @@ apps:
     url: https://www.standu.ps/oidc/callback/
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: iQk5ysxf2Cx5o85fIjEJi0ARCMFvSdTF
     display: false
@@ -1789,7 +1820,8 @@ apps:
     url: https://sso.core.us-west-2.tpe-marketing.nubis.allizom.org/sso
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: jUNRL0G9LVGyxROwV42QJSyf7jh67960
     display: false
@@ -1799,7 +1831,8 @@ apps:
     url: https://standupstage.herokuapp.com/oidc/callback/
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: lDyt2V0UvWdXsWj4lgcENLZ10E6TJ0Yt
     display: false
@@ -1809,7 +1842,8 @@ apps:
     url: https://pulseguardian-dev.allizom.org:5000/redirect_uri
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: t17aylgO4Jw6lvSEFuO9kFVxNm4Fb04z
     display: false
@@ -1819,7 +1853,8 @@ apps:
     url: https://moderator-staging.production.paas.mozilla.community/oidc/callback/
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: t6K0dg86KPvhkIgFAFz1CyC6reG8UV21
     display: false
@@ -1829,7 +1864,8 @@ apps:
     url: http://localhost:9000/callback
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: w5mW5ZufRCWg6metsZ7hMckSH5s3b1Cq
     display: false
@@ -1839,7 +1875,8 @@ apps:
     url: https://air.allizom.org/authentication/callback/
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: wBrqQY7k2sCNWQTeBLl4B6nDEDOesXG9
     display: false
@@ -1849,7 +1886,8 @@ apps:
     url: https://mozillastaging.wake.com/saml2/acs
 - application:
     AAL: LOW
-    authorized_groups: []
+    authorized_groups:
+    - everyone
     authorized_users: []
     client_id: ytxE7FfAMnFOXw3bF7SgKv6PwklueYUW
     display: false

--- a/apps.yml
+++ b/apps.yml
@@ -38,6 +38,7 @@ apps:
     vanity_url:
     - /echosign
 - application:
+    AAL: LOW
     authorized_groups:
     - everyone
     authorized_users: []
@@ -50,6 +51,7 @@ apps:
     vanity_url:
     - /airmo
 - application:
+    AAL: LOW
     authorized_groups:
     - everyone
     authorized_users: []
@@ -579,6 +581,7 @@ apps:
     vanity_url:
     - /moderator
 - application:
+    AAL: LOW
     authorized_groups:
     - everyone
     authorized_users: []
@@ -706,6 +709,7 @@ apps:
     vanity_url:
     - /productplan
 - application:
+    AAL: LOW
     authorized_groups:
     - everyone
     authorized_users: []
@@ -927,6 +931,7 @@ apps:
     op: auth0
     url: https://dataviz.allizom.org/
 - application:
+    AAL: LOW
     authorized_groups:
     - everyone
     authorized_users: []
@@ -968,6 +973,7 @@ apps:
     - /thehub
     - /servicenow
 - application:
+    AAL: LOW
     authorized_groups:
     - everyone
     authorized_users: []
@@ -1310,6 +1316,7 @@ apps:
     vanity_url:
     - /gcp
 - application:
+    AAL: LOW
     authorized_groups:
     - everyone
     authorized_users: []
@@ -1443,3 +1450,383 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/iz2qSHo0lSv2nRZ8V3JnOESX5UR4dcpX
     vanity_url:
     - /navex
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: 1tAZ7tyiARXodCaLoy38jYmzKLqjyDX8
+    display: false
+    logo: auth0.png
+    name: confluence.mozilla-community.org
+    op: auth0
+    url: https://confluence.mozilla-community.org/plugins/servlet/samlsso
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: 7RvvmjstmMm93e1eVimyRElqv8vjrEJC
+    display: false
+    logo: auth0.png
+    name: mcws.wpengine.com
+    op: auth0
+    url: https://wpengine.mcws.mozilla.community/
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: 7wyIItkJX4t7vYEaDmGrwP9k2fBh5qWP
+    display: false
+    logo: auth0.png
+    name: prod.testrp.security.allizom.org
+    op: auth0
+    url: https://prod.testrp.security.allizom.org/redirect_uri
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: 8J731AkHnZXviXJWzM2kdQTENMJMSVNI
+    display: false
+    logo: auth0.png
+    name: jenkins.services.mozilla.community
+    op: auth0
+    url: https://jenkins.services.mozilla.community/redirect_uri
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: 8fsFs05sqRr0Gt3RGm4Jh0AYNyByjXKt
+    display: false
+    logo: auth0.png
+    name: mon.admin.us-west-2.nubis-gozer.nubis.allizom.org
+    op: auth0
+    url: https://mon.admin.us-west-2.nubis-gozer.nubis.allizom.org/redirect
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: 9D6nm17QufE7lvipnl8l7sVHWCaElnrL
+    display: false
+    logo: auth0.png
+    name: standupdev.herokuapp.com
+    op: auth0
+    url: https://standupdev.herokuapp.com/
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: 9LGw821wb6hHd30HZWMy3eBE3JMtuDLs
+    display: false
+    logo: auth0.png
+    name: taskcluster demo - http://localhost:5050/
+    op: auth0
+    url: http://localhost:5050/login
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: 9sl5SW42wjikqzf9DXZSxzD8BHPf456e
+    display: false
+    logo: auth0.png
+    name: air-dev.allizom.org
+    op: auth0
+    url: https://air-dev.allizom.org/oidc/callback/
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: CPnG4kKY6vWH39q2adBEyxFRAE0lO7bm
+    display: false
+    logo: auth0.png
+    name: opensource.mozilla.community - localhost
+    op: auth0
+    url: http://localhost:8080/oidc/callback
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: CeA3IcqB1hc2Sbsxmtm909rbeInXv69s
+    display: false
+    logo: auth0.png
+    name: https://sso.core.us-west-2.nubis-jd.nubis.allizom.org/sso
+    op: auth0
+    url: https://sso.admin.us-west-2.nubis-jd.nubis.allizom.org/sso
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: CtXC7ukVJO7T3kfAwdvHLjxiV0eLFTaZ
+    display: false
+    logo: auth0.png
+    name: nubis-training.nubis.allizom.org
+    op: auth0
+    url: https://sso.admin.us-west-2.nubis-training.nubis.allizom.org/sso
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: DVvwftNuKq4miIQ0HDy7YqlkfilCAuLp
+    display: false
+    logo: auth0.png
+    name: crash-stats - localhost
+    op: auth0
+    url: http://localhost:8000/oidc/callback/
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: FQw134gwheaK3KkW6fQf0JPV6P7h2yo1
+    display: false
+    logo: auth0.png
+    name: https://web-mozillians-staging.production.paas.mozilla.community
+    op: auth0
+    url: https://web-mozillians.dinopark.infra.iam.mozilla.com/oidc/callback/
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: Hg3vUmTAlI2sFXR6Z4cy0Lm1hgKRapf6
+    display: false
+    logo: auth0.png
+    name: pulseguardian.mozilla.org
+    op: auth0
+    url: https://pulseguardian.mozilla.org/auth/callback
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: I2T4dYNc0dj2u1C8qbddYipgnpVtEd1K
+    display: false
+    logo: auth0.png
+    name: mon.stage.us-west-2.nubis-gozer.nubis.allizom.org
+    op: auth0
+    url: https://sso.stage.us-west-2.nubis-gozer.nubis.allizom.org/sso
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: M9OoQEQVR0M1qtyGvPql3ZDi4T7XMQEA
+    display: false
+    logo: auth0.png
+    name: tools.taskcluster.net
+    op: auth0
+    url: https://tools.taskcluster.net/login/auth0
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: NI6D4Rk4QCZIlLOBKmTtPvrz5CyMBm23
+    display: false
+    logo: auth0.png
+    name: web-remo-staging.production.paas.mozilla.community
+    op: auth0
+    url: https://web-remo-staging.production.paas.mozilla.community/oidc/callback/
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: OwbZj5f5NnK161LTtOVshM131Nf6jWBe
+    display: false
+    logo: auth0.png
+    name: https://respond.mozilla.community
+    op: auth0
+    url: https://respond.mozilla.community/oidc/callback/
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: Qp7DIxm4B16jnTcXsR6fai1X0a8GWVBZ
+    display: false
+    logo: auth0.png
+    name: mon.prod.us-west-2.nubis-gozer.nubis.allizom.org
+    op: auth0
+    url: https://mon.prod.us-west-2.nubis-gozer.nubis.allizom.org/redirect
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: RaxnXTpQY5WyVVw6I2mSLblbljiGH8B2
+    display: false
+    logo: auth0.png
+    name: moderator.mozilla.org
+    op: auth0
+    url: https://moderator.mozilla.org/oidc/callback/
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: SSG7PVY70x785oW1noHJZi1Ck2wzdlyM
+    display: false
+    logo: auth0.png
+    name: taskcluster-tools.ngrok.io/oidc-login
+    op: auth0
+    url: https://taskcluster-tools.ngrok.io/oidc-login
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: StXJySdOLGiWbnnmUGTC5zRGDymFSBO1
+    display: false
+    logo: auth0.png
+    name: https://github.com/comzeradd/auth0-python-web-app
+    op: auth0
+    url: http://127.0.0.1:8000/oidc/callback/
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: Tpd4uL15gBCjbypCYERVffaCuDx7hFPc
+    display: false
+    logo: auth0.png
+    name: discourse-localhost-development-leo-mcardle
+    op: auth0
+    url: http://localhost:3000/auth/auth0/callback
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: U4mXW5E6cfBqLziVewwkxApHGFNPA2pI
+    display: false
+    logo: auth0.png
+    name: jira.mozilla-community.org
+    op: auth0
+    url: https://jira.mozilla-community.org/plugins/servlet/samlsso
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: UCOY390lYDxgj5rU8EeXRtN6EP005k7V
+    display: false
+    logo: auth0.png
+    name: sso.mozilla.com
+    op: auth0
+    url: https://sso.mozilla.com/redirect_uri
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: YwL6bJ8mXFiCplWbMLaX2fqu715rKP8u
+    display: false
+    logo: auth0.png
+    name: voice.mozilla.org
+    op: auth0
+    url: https://voice.mozilla.org/callback
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: ZShocyal5HnbTYs7CH0rwytjTJGMFsav
+    display: false
+    logo: auth0.png
+    name: https://dinopark.k8s.dev.sso.allizom.org
+    op: auth0
+    url: https://dinopark.k8s.dev.sso.allizom.org/redirect_uri
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: aDL5o9SZRaYTH5zzkGntT4l76qydMbZe
+    display: false
+    logo: auth0.png
+    name: sso.allizom.org
+    op: auth0
+    url: http://localhost:5000/redirect_uri
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: aJc4zjynRegTcrrxjB7PqV8lb9FdAVBr
+    display: false
+    logo: auth0.png
+    name: discourse-staging.production.paas.mozilla.community
+    op: auth0
+    url: https://discourse-staging.production.paas.mozilla.community/auth/auth0/callback
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: c4j1TRdnJPdkFGJoEsU5LtL3ltPC5QyU
+    display: false
+    logo: auth0.png
+    name: www.standu.ps
+    op: auth0
+    url: https://www.standu.ps/oidc/callback/
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: iQk5ysxf2Cx5o85fIjEJi0ARCMFvSdTF
+    display: false
+    logo: auth0.png
+    name: sso.core.us-west-2.tpe-marketing.nubis.allizom.org
+    op: auth0
+    url: https://sso.core.us-west-2.tpe-marketing.nubis.allizom.org/sso
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: jUNRL0G9LVGyxROwV42QJSyf7jh67960
+    display: false
+    logo: auth0.png
+    name: standupstage.herokuapp.com
+    op: auth0
+    url: https://standupstage.herokuapp.com/oidc/callback/
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: lDyt2V0UvWdXsWj4lgcENLZ10E6TJ0Yt
+    display: false
+    logo: auth0.png
+    name: pulseguardian-dev.herokuapp.com
+    op: auth0
+    url: https://pulseguardian-dev.allizom.org:5000/redirect_uri
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: t17aylgO4Jw6lvSEFuO9kFVxNm4Fb04z
+    display: false
+    logo: auth0.png
+    name: moderator-staging.production.paas.mozilla.community.1
+    op: auth0
+    url: https://moderator-staging.production.paas.mozilla.community/oidc/callback/
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: t6K0dg86KPvhkIgFAFz1CyC6reG8UV21
+    display: false
+    logo: auth0.png
+    name: voice.allizom.org
+    op: auth0
+    url: http://localhost:9000/callback
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: w5mW5ZufRCWg6metsZ7hMckSH5s3b1Cq
+    display: false
+    logo: auth0.png
+    name: air.allizom.org
+    op: auth0
+    url: https://air.allizom.org/authentication/callback/
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: wBrqQY7k2sCNWQTeBLl4B6nDEDOesXG9
+    display: false
+    logo: auth0.png
+    name: mozillastaging.wake.com
+    op: auth0
+    url: https://mozillastaging.wake.com/saml2/acs
+- application:
+    AAL: LOW
+    authorized_groups: []
+    authorized_users: []
+    client_id: ytxE7FfAMnFOXw3bF7SgKv6PwklueYUW
+    display: false
+    logo: auth0.png
+    name: appsvcs-generic.nubis.allizom.org
+    op: auth0
+    url: https://sso.admin.us-west-2.appsvcs-generic.nubis.allizom.org/sso

--- a/apps.yml
+++ b/apps.yml
@@ -464,6 +464,9 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/0tHkuAC17kDkFip4szjsLvWHlXGJSjwc
 - application:
     authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
     - everyone
     authorized_users: []
     client_id: f4SlPDVeVcWBChrAvH8uLuEYyt0aW916
@@ -639,6 +642,9 @@ apps:
     - /optimizely
 - application:
     authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
     - everyone
     authorized_users: []
     client_id: Gav1XmmrpBxts0zeDPOSfGesVrTt044k
@@ -746,6 +752,9 @@ apps:
     url: https://riskheatmap.security.allizom.org/
 - application:
     authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
     - everyone
     authorized_users: []
     client_id: ByW5ChOPpsQaQFLcAuZBbtjFrh67uBgt
@@ -758,6 +767,9 @@ apps:
     - /salescloud
 - application:
     authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
     - everyone
     authorized_users: []
     client_id: 54KBW3ESzKFfQws77PCXziJnPt0dYHE0
@@ -888,6 +900,9 @@ apps:
     - /statuspage
 - application:
     authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
     - everyone
     authorized_users: []
     client_id: Wz5oO6y8oJ35Yq1B91aC4pkwlXdes7jR
@@ -1000,6 +1015,9 @@ apps:
     - /workday
 - application:
     authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
     - everyone
     authorized_users: []
     client_id: kyeMyPALPK84A58vlOnb7lrCzAIFJapP
@@ -1010,6 +1028,9 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/kyeMyPALPK84A58vlOnb7lrCzAIFJapP
 - application:
     authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
     - everyone
     authorized_users: []
     client_id: pRwf1AWvIO5t4zyMsF8R18wtt1jfLp5o
@@ -1062,6 +1083,9 @@ apps:
     - /convercentcommunity
 - application:
     authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
     - everyone
     authorized_users: []
     client_id: i55sTCbmgUTkvHPW3SDueKlKbtPj5iRF
@@ -1155,6 +1179,9 @@ apps:
     url: https://pto.mozilla.org/
 - application:
     authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
     - everyone
     authorized_users: []
     client_id: VjJFa4EeFWd29pMnhyAk7AkGW2ids5UX

--- a/apps.yml
+++ b/apps.yml
@@ -1,1137 +1,1445 @@
----
 apps:
-  - application:
-      name: "Account Portal"
-      op: auth0
-      url: "https://login.mozilla.com/"
-      logo: "accountmanager.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: true
-      vanity_url: ['/accountmanager']
-  - application:
-      name: "Adaptive Insights"
-      client_id: "el46s4SPK4ZOhQBsAjtiDYKFQkXK76xm"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/el46s4SPK4ZOhQBsAjtiDYKFQkXK76xm"
-      logo: "adaptive_insights.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: false
-      vanity_url: ['/adaptive']
-  - application:
-      name: "Adobe EchoSign"
-      client_id: "9F55B8e5VmFl4lCgYObnA1TkyRFTxQ9M"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/9F55B8e5VmFl4lCgYObnA1TkyRFTxQ9M"
-      logo: "adobe-sign.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: false
-      vanity_url: ['/echosign']
-  - application:
-      name: "Air Mozilla"
-      client_id: "7euXeq96glWUS85bwDRCCs10xKGY93t0"
-      op: auth0
-      url: "https://onlinexperiences.com/scripts/Server.nxp?LASCmd=L:0&AI=1&InitialDisplay=1&ClientBrowser=0&ShowKey=44908"
-      logo: "airmo.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: true
-      vanity_url: ['/airmo']
-  - application:
-      name: "Air Mozilla (Legacy)"
-      client_id: "nV1rnMMkB4uX9IewNOCitqy8NoyXVHlM"
-      op: auth0
-      url: "https://air.mozilla.org"
-      logo: "legacy-airmo.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: true
-      vanity_url: ['/legacy-airmo']
-  - application:
-      name: "Amplitude"
-      client_id: "ql6V6DHXglhTCq9qe6DPdV3eAW2da44F"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/ql6V6DHXglhTCq9qe6DPdV3eAW2da44F"
-      logo: "amplitude.png"
-      authorized_users: ['moc+servicenow@mozilla.com', 'moc-sso-monitoring@mozilla.com']
-      authorized_groups: ['team_moco', 'team_mofo', 'team_mozillajapan', 'team_mozillaonline', 'moc_service_accounts']
-      display: true
-      vanity_url: ['/amplitude']
-  - application:
-      name: "Anaplan"
-      client_id: "xAJuHbCa1v0mPp72QMm88hYA2dFEvSy5"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/xAJuHbCa1v0mPp72QMm88hYA2dFEvSy5"
-      logo: "anaplan.png"
-      authorized_users: []
-      authorized_groups: ['team_moco']
-      display: false
-      vanity_url: ['/anaplan']
-  - application:
-      name: "ASAP (AWS Security Auditing Platform)"
-      client_id: "snpYGrMjpcnNlz7FlXxgFs9ok7IRz83g"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/snpYGrMjpcnNlz7FlXxgFs9ok7IRz83g"
-      logo: "asap.png"
-      authorized_users: []
-      authorized_groups: ['team_opsec']
-      display: true
-  - application:
-      name: "Basket"
-      client_id: "14G95j0WAteSbDicn75gsZvRPXN6bkQm"
-      op: auth0
-      url: "https://basket-admin.us-west.moz.works/oidc/authenticate/"
-      logo: "basket.png"
-      authorized_users: []
-      authorized_groups: ['service_basket']
-      display: true
-  - application:
-      name: "Basket Dev"
-      client_id: "xZsLG6eg9XjFm5vHKNi4pgE12gfpQM1p"
-      op: auth0
-      url: "https://basket-dev.allizom.org/oidc/authenticate/"
-      logo: "basket.png"
-      authorized_users: []
-      authorized_groups: ['service_basket']
-      display: true
-  - application:
-      name: "Basket Staging"
-      client_id: "vBgSD2axkzQ6UnC20AFTko0oRr3elwa6"
-      op: auth0
-      url: "https://basket-admin-stage.us-west.moz.works/oidc/authenticate/"
-      logo: "basket.png"
-      authorized_users: []
-      authorized_groups: ['service_basket']
-      display: true
-  - application:
-      name: "Beckon"
-      client_id: "ZtHVNezP0k2vuZnAg5zbRuFTz76vrXpZ"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/ZtHVNezP0k2vuZnAg5zbRuFTz76vrXpZ"
-      logo: "beckon.png"
-      authorized_users: []
-      authorized_groups: ['service_beckon']
-      display: true
-      vanity_url: ['/beckon']
-  - application:
-      name: "Casa"
-      client_id: "IU80mVpKPtIZyUZtya9ZnSTs6fKLt3JO"
-      op: auth0
-      url: "https://biztera.com/mozilla"
-      logo: "biztera.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: true
-      vanity_url: ['/casa']
-  - application:
-      name: "CloudHealth"
-      client_id: "kvfwYzMi40o93JJuuzfdwzeXnnJghgwN"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/kvfwYzMi40o93JJuuzfdwzeXnnJghgwN"
-      logo: "cloudhealth.png"
-      authorized_users: []
-      authorized_groups: ['cloudhealth-power', 'cloudhealth-standard', 'cloudhealth-administrator', 'cloudhealth-enhanced-power-user', 'cloudhealth-enhanced-standard-user']
-      display: true
-      vanity_url: ['/cloudhealth']
-  - application:
-      name: "Community Analytics"
-      client_id: "BbenZUhB0TUVZnAtYvysfvpZKNHby4JX"
-      op: auth0
-      url: "https://analytics.mozilla.community"
-      logo: "bitergia.png"
-      authorized_users: []
-      authorized_groups: ['mozilliansorg_nda', 'team_moco', 'team_mofo']
-      display: true
-      vanity_url: ['/analytics']
-  - application:
-      name: "Consolidated Billing AWS"
-      client_id: "koX1ze40wpoUovVV3RA7K79uTlxpbZFp"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/koX1ze40wpoUovVV3RA7K79uTlxpbZFp"
-      logo: "aws.png"
-      authorized_users: []
-      authorized_groups: ['aws_consolidatedbilling_read_only']
-      display: true
-  - application:
-      name: "Discourse"
-      client_id: "rehgg9cqVmHJbHw3jPYUzoU5BYYBH6XL"
-      op: auth0
-      url: "https://discourse.mozilla.org/auth/auth0"
-      logo: "discourse.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: true
-      vanity_url: ['/discourse']
-      AAL: "LOW"
-  - application:
-      name: "Discourse Staging"
-      client_id: "RqUns8zD5oTsEsjTKAUMhF55sLfuQsGv"
-      op: auth0-dev
-      url: "https://discourse-staging.production.paas.mozilla.community/auth/auth0"
-      logo: "discourse.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-      vanity_url: ['/discourse-stage']
-      AAL: "LOW"
-  - application:
-      name: "Discourse-Dev"
-      client_id: "3LIXec4tKVr6SltYFYUYsE0GIw0Jm2T0"
-      op: auth0-dev
-      url: "https://discourse.allizom.org/auth/auth0"
-      logo: "discourse.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-      vanity_url: ['/discourse-dev']
-      AAL: "LOW"
-
-  - application:
-      name: "Domo"
-      client_id: "72Q4MlsbMzRo5Sij6y5JPDAiyGcyDKB2"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/72Q4MlsbMzRo5Sij6y5JPDAiyGcyDKB2"
-      logo: "domo.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: false
-      vanity_url: ['/domo']
-  - application:
-      name: "DXR"
-      client_id: "GmGXMS6RJt3ZvabfTjx16B97pETlnUxd"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/GmGXMS6RJt3ZvabfTjx16B97pETlnUxd"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-  - application:
-      name: "DXR-stage"
-      client_id: "kNsY9QiOy7pSUjiordq7WixztBPCepuD"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/kNsY9QiOy7pSUjiordq7WixztBPCepuD"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-  - application:
-      name: "Egencia"
-      op: auth0
-      url: "https://www.egencia.com/pub/agent.dll?qscr=vain&vain=mozilla"
-      logo: "egencia.png"
-      authorized_users: []
-      authorized_groups: ['egencia_us', 'egencia_ca']
-      display: true
-      vanity_url: ['/egencia']
-  - application:
-      name: "Egencia (UK)"
-      op: auth0
-      url: "https://www.egencia.com/auth/v1/login?call-back-url=aHR0cDovL21vemlsbGEuZWdlbmNpYS5jby51ay9hcHA%2Fc2VydmljZT1leHRlcm5hbCZwYWdlPUxvZ2luJm1vZGU9Zm9ybSZtYXJrZXQ9R0I%3D"
-      logo: "egencia.png"
-      authorized_users: []
-      authorized_groups: ['egencia_uk']
-      display: true
-      vanity_url: ['/egenciauk']
-  - application:
-      name: "Egencia (CA)"
-      op: auth0
-      url: "http://www.egencia.ca/pub/agent.dll?qscr=vain&amp;vain=mozilla"
-      logo: "egencia.png"
-      authorized_users: []
-      authorized_groups: ['egencia_ca']
-      display: false
-      vanity_url: ['/egenciaca']
-  - application:
-      name: "Egencia (APAC)"
-      op: auth0
-      url: "https://www.egencia.com/auth/v1/login?call-back-url=aHR0cDovL21vemlsbGEuZWdlbmNpYS5jb20uc2cvYXBwP3NlcnZpY2U9ZXh0ZXJuYWwmcGFnZT1Mb2dpbiZtb2RlPWZvcm0mbWFya2V0PVNH"
-      logo: "egencia.png"
-      authorized_users: []
-      authorized_groups: ['egencia_apac']
-      display: true
-      vanity_url: ['/egenciaapac']
-  - application:
-      name: "Egencia (DE)"
-      op: auth0
-      url: "https://www.egencia.com/auth/v1/login?call-back-url=aHR0cDovL21vemlsbGEuZWdlbmNpYS5kZS9hcHA%2Fc2VydmljZT1leHRlcm5hbCZwYWdlPUxvZ2luJm1vZGU9Zm9ybSZtYXJrZXQ9REU%3D"
-      logo: "egencia.png"
-      authorized_users: []
-      authorized_groups: ['egencia_de']
-      display: true
-      vanity_url: ['/egenciade']
-  - application:
-      name: "Egencia (FR)"
-      op: auth0
-      url: "https://www.egencia.com/auth/v1/login?call-back-url=aHR0cDovL21vemlsbGEuZWdlbmNpYS5mci9hcHA%2Fc2VydmljZT1leHRlcm5hbCZwYWdlPUxvZ2luJm1vZGU9Zm9ybSZtYXJrZXQ9RlI%3D"
-      logo: "egencia.png"
-      authorized_users: []
-      authorized_groups: ['egencia_fr']
-      display: true
-      vanity_url: ['/egenciafr']
-  - application:
-      name: "EventBoard"
-      client_id: "DhBV04HLs6H8OeTHOlodz0LtkyY7VTU0"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/DhBV04HLs6H8OeTHOlodz0LtkyY7VTU0"
-      logo: "eventboard.png"
-      authorized_users: []
-      authorized_groups: ['service_eventboard']
-      display: false
-      vanity_url: ['/eventboard']
-  - application:
-      name: "Marketing Cloud"
-      client_id: "Qxc2EI4g0NymUBvfFKpuwPdSzJZX5TEN"
-      op: auth0
-      url: "https://auth.s1.exacttarget.com/sso/f56e153c30265a772451342d7a59223f4d2c29351a2c305028757a572228"
-      logo: "exacttarget.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo', 'team_mozillajapan', 'team_mozillaonline']
-      display: false
-      vanity_url: ['/marketingcloud']
-  - application:
-      name: "Gmail"
-      client_id: "smKTjsVVxUJDEkjIftOsP0bop2NWjysa"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/smKTjsVVxUJDEkjIftOsP0bop2NWjysa?RelayState=https://mail.google.com/"
-      logo: "gmail.png"
-      authorized_users: ['moc+servicenow@mozilla.com', 'moc-sso-monitoring@mozilla.com']
-      authorized_groups: ['team_moco', 'team_mofo', 'team_mozillajapan', 'team_mozillaonline', 'gsuite_shared_accounts', 'moc_service_accounts']
-      display: true
-      vanity_url: ['/gmail']
-  - application:
-      name: "Google Calendar"
-      client_id: "smKTjsVVxUJDEkjIftOsP0bop2NWjysa"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/smKTjsVVxUJDEkjIftOsP0bop2NWjysa?RelayState=https://calendar.google.com/"
-      logo: "gcal.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo', 'team_mozillajapan', 'team_mozillaonline', 'gsuite_shared_accounts', 'moc_service_accounts']
-      display: true
-      vanity_url: ['/gcalendar']
-  - application:
-      name: "Google Drive"
-      client_id: "smKTjsVVxUJDEkjIftOsP0bop2NWjysa"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/smKTjsVVxUJDEkjIftOsP0bop2NWjysa?RelayState=https://drive.google.com/"
-      logo: "gdrive.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo', 'team_mozillajapan', 'team_mozillaonline', 'gsuite_shared_accounts', 'moc_service_accounts']
-      display: true
-      vanity_url: ['/gdrive']
-  - application:
-      name: "Greenhouse"
-      client_id: "TGlmvMW4kvEz99CRnuGnNTfxku0QNn8e"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/TGlmvMW4kvEz99CRnuGnNTfxku0QNn8e"
-      logo: "greenhouse.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: true
-      vanity_url: ['/greenhouse']
-  - application:
-      name: "Heroku"
-      client_id: "KOyQ76xjXqtsPgt4ci4bThpIz3a1396E"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/KOyQ76xjXqtsPgt4ci4bThpIz3a1396E"
-      authorized_users: []
-      authorized_groups: ['mozilliansorg_heroku-members']
-      display: true
-      logo: "auth0.png"
-      vanity_url: ['/heroku']
-  - application:
-      name: "Intranet"
-      client_id: "3TMLWJb8KIbjB1S3HeyjDm0ns192BTdZ"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/3TMLWJb8KIbjB1S3HeyjDm0ns192BTdZ"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['IntranetWiki']
-      display: false
-  - application:
-      name: "Intranet-stage"
-      client_id: "0tHkuAC17kDkFip4szjsLvWHlXGJSjwc"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/0tHkuAC17kDkFip4szjsLvWHlXGJSjwc"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['IntranetWiki']
-      display: false
-  - application:
-      name: "iplimitirc"
-      client_id: "f4SlPDVeVcWBChrAvH8uLuEYyt0aW916"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/f4SlPDVeVcWBChrAvH8uLuEYyt0aW916"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-  - application:
-      name: "IRCCloud"
-      client_id: "D4hqwOVDV2UUJBW2FwD1RxnguPm14Mv3"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/D4hqwOVDV2UUJBW2FwD1RxnguPm14Mv3"
-      logo: "irccloud.png"
-      authorized_users: []
-      authorized_groups: ['irccloud']
-      display: true
-      vanity_url: ['/irccloud']
-  - application:
-      name: "LucidChart"
-      client_id: "80JNexePA737rSLhBAABqIvMJTEAn11u"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/80JNexePA737rSLhBAABqIvMJTEAn11u"
-      logo: "lucidchart.png"
-      authorized_users: []
-      authorized_groups: ['service_lucidchart']
-      display: true
-      vanity_url: ['/lucidchart']
-  - application:
-      name: "Mana"
-      client_id: "LVjFyOpHUdAJTLkTmDnUADnQmUKOWXO2"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/LVjFyOpHUdAJTLkTmDnUADnQmUKOWXO2"
-      logo: "mana.png"
-      authorized_users: ['moc+servicenow@mozilla.com', 'moc-sso-monitoring@mozilla.com']
-      authorized_groups: ['IntranetWiki', 'GuestWiki', 'moc_service_accounts']
-      display: true
-      vanity_url: ['/mana']
-  - application:
-      name: "Jira"
-      client_id: "zXilPvZm4Vy2c2YcpMslENEtGXHWc5Rq"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/zXilPvZm4Vy2c2YcpMslENEtGXHWc5Rq"
-      logo: "jira.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo', 'team_mozillajapan', 'team_mozillaonline', 'moc_service_accounts']
-      display: true
-      vanity_url: ['/jira']
-  - application:
-      name: "Mana Stage"
-      client_id: "IuWFSguzDAqbTT4qdtmABNdCVayuCWy5"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/IuWFSguzDAqbTT4qdtmABNdCVayuCWy5"
-      logo: "mana.png"
-      authorized_users: []
-      authorized_groups: ['service_mana_stage']
-      display: false
-  - application:
-      name: "Data Collective"
-      client_id: "wAXfZ9Z2JS3gRMbY6G3uxzUZTNO1YPwh"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/wAXfZ9Z2JS3gRMbY6G3uxzUZTNO1YPwh?RelayState=https://www.mozdatacollective.com"
-      logo: "mdc.png"
-      authorized_users: ['moc+servicenow@mozilla.com', 'moc-sso-monitoring@mozilla.com']
-      authorized_groups: ['mozilliansorg_nda','team_moco', 'team_mofo', 'team_mozillajapan', 'team_mozillaonline', 'moc_service_accounts']
-      display: true
-      vanity_url: ['/mdc']
-  - application:
-      name: "MDN Web Docs"
-      op: auth0
-      url: "https://developer.mozilla.org/"
-      logo: "mdn.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: true
-      vanity_url: ['/mdn']
-  - application:
-      name: "Moderator"
-      client_id: "nPr8QRo0dLxM3RRHwIXRSvhmOSPDvNr4"
-      op: auth0
-      url: "https://moderator.mozilla.org/oidc/authenticate/"
-      logo: "moderator.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: true
-      vanity_url: ['/moderator']
-  - application:
-      name: "Mozillians"
-      client_id: "HdfEiM1SZibaQnOYTxLoMdxSh4a6ZKD3"
-      op: auth0
-      url: "https://mozillians.org/oidc/authenticate/"
-      logo: "mozillians.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: true
-      vanity_url: ['/mozillians']
-  - application:
-      name: "Mozillians Staging"
-      client_id: "T2tB7Ss8It7PKrw3ijazoXu9PgZniLPD"
-      op: auth0
-      url: "https://web-mozillians-staging.production.paas.mozilla.community/oidc/authenticate/"
-      logo: "mozillians.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-      AAL: "LOW"
-  - application:
-      name: "Nucleus"
-      client_id: "a6cidU6mSbciFAjy4uRQeeuFHIsLIWgg"
-      op: auth0
-      url: "https://nucleus.mozilla.org/oidc/authenticate/"
-      logo: "nucleus.png"
-      authorized_users: []
-      authorized_groups: ['service_nucleus_prod']
-      display: true
-  - application:
-      name: "Nucleus Dev"
-      client_id: "grGFAm6XbCYn3feUbyg5i9M6eyQHuhe6"
-      op: auth0
-      url: "https://nucleus-dev.frankfurt.moz.works/oidc/authenticate/"
-      logo: "nucleus.png"
-      authorized_users: []
-      authorized_groups: ['service_nucleus_dev']
-      display: true
-  - application:
-      name: "Optimizely"
-      client_id: "4HNLHcA7ZSNVWSJVBk9yVxq06WRquN2L"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/4HNLHcA7ZSNVWSJVBk9yVxq06WRquN2L"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: false
-      vanity_url: ['/optimizely']
-  - application:
-      name: "PagerDuty"
-      client_id: "Gav1XmmrpBxts0zeDPOSfGesVrTt044k"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/Gav1XmmrpBxts0zeDPOSfGesVrTt044k"
-      logo: "pagerduty.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-      vanity_url: ['/pagerduty']
-  - application:
-      name: "Phonebook"
-      client_id: "K7vKewjQHKe45mmOo5cRae6yyOvnmg74"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/K7vKewjQHKe45mmOo5cRae6yyOvnmg74"
-      logo: "phonebook.png"
-      authorized_users: []
-      authorized_groups: ['phonebook_access']
-      display: true
-      vanity_url: ['/phonebook']
-  - application:
-      name: "Phonebook Stage"
-      client_id: "00fgOKsjo530sIxfhsved8jyTjAD0av2"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/00fgOKsjo530sIxfhsved8jyTjAD0av2"
-      logo: "phonebook.png"
-      authorized_users: []
-      authorized_groups: ['phonebook_access']
-      vanity_url: ['/phonebook-stage']
-      display: false
-  - application:
-      name: "PHPLDAPAdmin"
-      client_id: "0w4E1e2qbcA44oQKfYiUF167pc2l1Lud"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/0w4E1e2qbcA44oQKfYiUF167pc2l1Lud?RelayState=https://ldapadmin1.private.scl3.mozilla.com/phpldapadmin/"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['ldapAdmins']
-      display: true
-  - application:
-      name: "PlanSource Benefits"
-      client_id: "DBRlLjVEUbw1yWrUYAHNYl22KBkKAjql"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/DBRlLjVEUbw1yWrUYAHNYl22KBkKAjql?RelayState=https://benefits.plansource.com/sso/employee/saml2/post/d4f3574247aa2707"
-      logo: "plansource.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: true
-      vanity_url: ['/plansource']
-  - application:
-      name: "ProductPlan"
-      client_id: "Ky8RbBLJ36PhlagJMT46ru6DWW8AK451"
-      op: auth0
-      url: "https://desktop.pingone.com/mozilla/url?source=application&url=https%3A%2F%2Fsso.connect.pingidentity.com%2Fsso%2Fsp%2Finitsso%3Fsaasid%3D72a035e2-0939-4685-aa8a-8c731729298b%26idpid%3Dmozilla.com&title=IDP%20Connection&applicationtype=APPLICATION_DEFAULT&saasid=72a035e2-0939-4685-aa8a-8c731729298b&newDock=true"
-      logo: "productplan.png"
-      authorized_users: []
-      authorized_groups: ['service_productplan']
-      display: true
-      vanity_url: ['/productplan']
-  - application:
-      name: "Reps"
-      client_id: "zwpij4T2QTt7QdbmdpkAG5FQgoeSRbyB"
-      op: auth0
-      url: "https://reps.mozilla.org/oidc/authenticate/"
-      logo: "reps.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: true
-      vanity_url: ['/reps']
-  - application:
-      name: "RiskHeatMap"
-      client_id: "3rbiX5U5EZZFf9tvYpOdoUxJ6A2TnH2q"
-      op: auth0
-      url: "https://riskheatmap.security.mozilla.org/"
-      logo: "riskheatmap.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: true
-      vanity_url: ['/riskheatmap']
-  - application:
-      name: "RiskHeatMap (Dev)"
-      client_id: "5vVAvF2lo36Nj576GqZTTsbXzZ1AH21L"
-      op: auth0
-      url: "https://riskheatmap.security.allizom.org/"
-      logo: "riskheatmap.png"
-      authorized_users: []
-      authorized_groups: ['SecurityAssuranceOpsec']
-      display: true
-  - application:
-      name: "SalesCloud"
-      client_id: "ByW5ChOPpsQaQFLcAuZBbtjFrh67uBgt"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/ByW5ChOPpsQaQFLcAuZBbtjFrh67uBgt"
-      logo: "salescloud.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-      vanity_url: ['/salescloud']
-  - application:
-      name: "Salesforce.com Dev Sandbox"
-      client_id: "54KBW3ESzKFfQws77PCXziJnPt0dYHE0"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/54KBW3ESzKFfQws77PCXziJnPt0dYHE0"
-      logo: "salescloud.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-  - application:
-      name: "Securitywiki"
-      client_id: "js47vk5Ncr7Rv4SUyIyVBRXvlRSLrHVG"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/js47vk5Ncr7Rv4SUyIyVBRXvlRSLrHVG"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'SecurityWiki']
-      display: false
-  - application:
-      name: "Securitywiki-stage"
-      client_id: "OWVEwzt059vjws6mkQgGeqJChA4dBI70"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/OWVEwzt059vjws6mkQgGeqJChA4dBI70"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'SecurityWiki']
-      display: false
-  - application:
-      name: "ServiceNow - Dev"
-      client_id: "Hy16dlY3Kmw373jWKVeMGulVUTt1y1KX"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/Hy16dlY3Kmw373jWKVeMGulVUTt1y1KX"
-      logo: "servicenow.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: false
-  - application:
-      name: "ServiceNow - Stage"
-      client_id: "DIx9YBxmtAWGGSV6nc21wSEXuymRSvY9"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/DIx9YBxmtAWGGSV6nc21wSEXuymRSvY9"
-      logo: "servicenow.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: false
-  - application:
-      name: "ServiceNow - Test"
-      client_id: "dPlqnxe8phbjbhm80W1Ry8SzSGS3ijuh"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/dPlqnxe8phbjbhm80W1Ry8SzSGS3ijuh"
-      logo: "servicenow.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: false
-  - application:
-      name: "ServiceNow - Upgrade"
-      client_id: "axoW08Nny1HXe0qcP0416YGrmYtfgdTQ"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/axoW08Nny1HXe0qcP0416YGrmYtfgdTQ"
-      logo: "servicenow.png"
-      authorized_users: ['moc+servicenow@mozilla.com', 'moc-sso-monitoring@mozilla.com']
-      authorized_groups: ['team_moco', 'team_mofo', 'moc_service_accounts']
-      display: false
-  - application:
-      name: "Smartsheet"
-      client_id: "l094SuNKnntJaVwkUU2tWxOsEtx5h3Oo"
-      op: auth0
-      url: "https://app.smartsheet.com/b/orgsso/C5AE787951B226D893639096D1863484"
-      logo: "smartsheet.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: true
-      vanity_url: ['/smartsheet', '/smartsheets']
-  - application:
-      name: "Snippets"
-      client_id: "A7GAcuN9gE9x3H186dKQgzS3jsV9Qmgp"
-      op: auth0
-      url: "https://snippets-admin.us-west.moz.works/oidc/authenticate/"
-      logo: "snippets.png"
-      authorized_users: []
-      authorized_groups: ['service_snippets']
-      display: true
-  - application:
-      name: "Splunk"
-      client_id: "EUmKs3owmNdeDWxZ4CJIeSGM5ez3Suav"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/EUmKs3owmNdeDWxZ4CJIeSGM5ez3Suav"
-      logo: "splunk.png"
-      authorized_users: []
-      authorized_groups: ['netops', 'splunk_admin', 'hris_dept_it']
-      display: true
-      vanity_url: ['/splunk']
-  - application:
-      name: "StatusPage"
-      client_id: "dc50KcxGnMPBOSlE5QLYaDRmfrO7oXhq"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/dc50KcxGnMPBOSlE5QLYaDRmfrO7oXhq"
-      logo: "statuspage.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: true
-      vanity_url: ['/statuspage']
-  - application:
-      name: "support.allizom.org:admin"
-      client_id: "Wz5oO6y8oJ35Yq1B91aC4pkwlXdes7jR"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/Wz5oO6y8oJ35Yq1B91aC4pkwlXdes7jR"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-  - application:
-      name: "support.mozilla.org:admin"
-      client_id: "a145ph7ZPSz97z8QkiuP1iId6MFPXXUH"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/a145ph7ZPSz97z8QkiuP1iId6MFPXXUH"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-  - application:
-      name: "Tableau (dataviz.mozilla.org)"
-      client_id: "J6oAK91WCqBLQjpG2v6U3yKyoN9FL13Q"
-      op: auth0
-      url: "https://dataviz.mozilla.org/"
-      logo: "tableau.png"
-      authorized_users: []
-      authorized_groups: ['tableau_users', 'moc_service_accounts']
-      display: true
-      vanity_url: ['/tableau']
-  - application:
-      name: "Tableau-staging"
-      client_id: "P42x7zxtymbHLvBysEustI6nJWZmMmtq"
-      op: auth0
-      url: "https://dataviz.allizom.org/"
-      logo: "tableau.png"
-      authorized_users: []
-      authorized_groups: ['tableau_users', 'moc_service_accounts']
-      display: false
-  - application:
-      name: "TaskCluster"
-      client_id: "1db5KNoLN5rLZukvLouWwVouPkbztyso"
-      op: auth0
-      url: "https://login.taskcluster.net"
-      logo: "taskcluster.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-      vanity_url: ['/taskcluster']
-  - application:
-      name: "Temp Admin - Consolidated Billing AWS"
-      client_id: "XA2fOQITX6rGNHy8DI3KuuRdccaKwsM6"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/XA2fOQITX6rGNHy8DI3KuuRdccaKwsM6"
-      logo: "aws.png"
-      authorized_users: []
-      authorized_groups: ['aws_consolidatedbilling_temporary_admin']
-      display: true
-  - application:
-      name: "The Hub"
-      client_id: "5gtZrLu2eyAapp1BgQsF11rhdPNt2lGP"
-      op: auth0
-      url: "https://mozilla.service-now.com/"
-      logo: "thehub.png"
-      authorized_users: ['moc+servicenow@mozilla.com', 'moc-sso-monitoring@mozilla.com']
-      authorized_groups: ['team_moco', 'team_mofo', 'team_mozillajapan', 'team_mozillaonline', 'moc_service_accounts']
-      display: true
-      vanity_url: ['/thehub', '/servicenow']
-  - application:
-      name: "Treeherder"
-      client_id: "q8fZZFfGEmSB2c5uSI8hOkKdDGXnlo5z"
-      op: auth0
-      url: "https://treeherder.mozilla.org"
-      logo: "treeherder.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: true
-      vanity_url: ['/treeherder']
-  - application:
-      name: "Workday"
-      client_id: "Hypn042D0cqtqET33nRrnqOwAcIXOqx6"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/Hypn042D0cqtqET33nRrnqOwAcIXOqx6"
-      logo: "workday.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: true
-      vanity_url: ['/workday']
-  - application:
-      name: "Workday - Preview"
-      client_id: "kyeMyPALPK84A58vlOnb7lrCzAIFJapP"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/kyeMyPALPK84A58vlOnb7lrCzAIFJapP"
-      logo: "workday.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-  - application:
-      name: "Workday - Sandbox"
-      client_id: "pRwf1AWvIO5t4zyMsF8R18wtt1jfLp5o"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/pRwf1AWvIO5t4zyMsF8R18wtt1jfLp5o"
-      logo: "workday.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-  - application:
-      name: "Slack"
-      client_id: "WXVdgVoCca11OtpGlK8Ir3pR9CBAlSA5"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/WXVdgVoCca11OtpGlK8Ir3pR9CBAlSA5"
-      logo: "slack.png"
-      authorized_users: []
-      authorized_groups: ['mozilliansorg_slack-access', 'team_moco', 'team_mofo', 'team_mozillaonline', 'hris_is_staff']
-      display: true
-      vanity_url: ['/slack']
-  - application:
-      name: "Convercent"
-      client_id: "meBoR5vlD0kK0qeUXshNjOB1PbGKjsro"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/meBoR5vlD0kK0qeUXshNjOB1PbGKjsro?RelayState=https://app.convercent.com/"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: false
-      vanity_url: ['/convercent']
-  - application:
-      name: "Convercent - Community"
-      client_id: "j8FN0DB6RwrlfLhX4opVAZ2tDYbBiMMU"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/j8FN0DB6RwrlfLhX4opVAZ2tDYbBiMMU?RelayState=https://app.convercent.com/"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: false
-      vanity_url: ['/convercentcommunity']
-  - application:
-      name: "OneTrust"
-      client_id: "i55sTCbmgUTkvHPW3SDueKlKbtPj5iRF"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/i55sTCbmgUTkvHPW3SDueKlKbtPj5iRF"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-  - application:
-      name: "Palo Alto Networks Panorama"
-      client_id: "z5zWsArYQgI63CEjMMtODh0DFtDr5oSz"
-      op: auth0
-      url: "https://panorama.mozilla.net/"
-      logo: "paloalto.png"
-      authorized_users: []
-      authorized_groups: ['netops', 'team_infra', 'team_moc', 'team_opsec', 'team_avops', 'team_relops', 'vpn_panorama']
-      display: true
-  - application:
-      name: "Analysis Telemetry"
-      client_id: "6GDrRrIYZuRRKLXXbucm4bO0eafK0AKN"
-      op: auth0
-      url: "https://analysis.telemetry.mozilla.org/"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo', 'cloudops_atmo_access']
-      display: false
-  - application:
-      name: "Netops Gitlab"
-      client_id: "GWhjnB7egp5hDryXeoD7OJRjHshWWQap"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/GWhjnB7egp5hDryXeoD7OJRjHshWWQap"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['netops', 'relops', 'team_opsec', 'team_moc']
-      display: false
-  - application:
-      name: "Apache Test RP"
-      client_id: "BRMXeyw2avAOj7GgBD4SuIHxopb0yZJP"
-      op: auth0-dev
-      url: "https://apache.testrp.security.allizom.org/"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['cis_whitelist', 'team_moco']
-      display: false
-  - application:
-      name: "AAL Low Test RP"
-      client_id: "FeqjZfpOqMIkcGKkd2fDjpnm5oSsOOZ2"
-      op: auth0-dev
-      url: "https://aai-low-social-ldap-pwless.testrp.security.allizom.org/"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-      AAL: "LOW"
-  - application:
-      name: "SSO Dashboard (Dev)"
-      client_id: "mc1l0G4sJI2eQfdWxqgVNcRAD9EAgHib"
-      op: auth0-dev
-      url: "https://sso.allizom.org/"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-  - application:
-      name: "PTO"
-      client_id: "Q3z1fjeoZhGyws1IXDUc6rHdcYNpxTv8"
-      op: auth0
-      url: "https://pto.mozilla.org/"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['team_moco']
-      display: false
-  - application:
-      name: "Desk"
-      client_id: "VjJFa4EeFWd29pMnhyAk7AkGW2ids5UX"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/VjJFa4EeFWd29pMnhyAk7AkGW2ids5UX"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['everyone']
-      display: false
-      vanity_url: ['/desk']
-  - application:
-      name: "Mozilla Defense Platform"
-      client_id: "PSCl3uIPg5IT2GaiOcAIJprYK7iBK32r"
-      op: auth0
-      url: "https://mozdef.infosec.mozilla.org/"
-      logo: "mozdef.png"
-      authorized_users: []
-      authorized_groups: ["hris_costcenter_1420", "vpn_opsec_mozdef", "team_moc", "team_secops"]
-      expire_access_when_unused_after: 7776000
-      display: true
-  - application:
-      name: "Mozilla Defense Platform QA"
-      client_id: "Dj0vncaBmaHn1zxzRc1cuFQIBxD0YSGp"
-      op: auth0
-      url: "https://mozdefqa1.private.mdc1.mozilla.com/"
-      logo: "mozdef.png"
-      authorized_users: []
-      authorized_groups: ["hris_costcenter_1420", "vpn_opsec_mozdef"]
-      expire_access_when_unused_after: 7776000
-      display: false
-  - application:
-      name: "Xmatters Stage"
-      client_id: "t1KWNQt71oskeip2KCu9j0KhwJJbBkig"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/t1KWNQt71oskeip2KCu9j0KhwJJbBkig"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: false
-  - application:
-      name: "Xmatters"
-      client_id: "uMkOuQX8LGTxAyYIiX4eLoc4hl0pWSJt"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/uMkOuQX8LGTxAyYIiX4eLoc4hl0pWSJt"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: false
-  - application:
-      name: "IAM AWS Account"
-      client_id: "2lTZtlpqx4bslng167l1BBqTMusCAJkZ"
-      vanity_url: ['/iam-infra']
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/2lTZtlpqx4bslng167l1BBqTMusCAJkZ"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['mozilliansorg_mozilla-iam-aws-access']
-      display: false
-  - application:
-      name: "IAM Grafana"
-      client_id: "nlE73wPPuOaN0wAYKWY6QD3VcjUStehZ"
-      vanity_url: ['/iam-grafana']
-      op: auth0
-      url: "https://grafana.infra.iam.mozilla.com/login/generic_oauth"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['mozilliansorg_mozilla-iam-aws-access']
-      display: false
-  - application:
-      name: "Box"
-      client_id: "yCKLKXrrkigZwoQ9d6xzmE5NuvVW0oBj"
-      op: auth0
-      vanity_url: ['/box']
-      url: "https://auth.mozilla.auth0.com/samlp/yCKLKXrrkigZwoQ9d6xzmE5NuvVW0oBj"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['mozilliansorg_nda', 'team_moco', 'team_mofo']
-      display: false
-  - application:
-      name: "AirTable"
-      client_id: "mKlNDH9c7JKO1Rh3HtGXdTtLntTlHefx"
-      op: auth0
-      vanity_url: ['/airtable']
-      url: "https://auth.mozilla.auth0.com/samlp/mKlNDH9c7JKO1Rh3HtGXdTtLntTlHefx"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['service_airtable']
-      display: false
-  - application:
-      name: "admin.readitlater.com"
-      client_id: "ChKEapjEYTPx0T1b5QP01WhAeP8ymRJ7"
-      op: auth0
-      url: "https://admin.readitlater.com"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: false
-  - application:
-      name: "Syntrio"
-      client_id: "2QnAFjxpltXc2dTkd9QW7nY43dx6xf5a"
-      op: auth0
-      vanity_url: ['/syntrio']
-      url: "https://auth.mozilla.auth0.com/samlp/2QnAFjxpltXc2dTkd9QW7nY43dx6xf5a"
-      logo: "syntrio.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mozillaonline']
-      display: true
-  - application:
-      name: "Expensify"
-      op: auth0
-      vanity_url: ['/expensify']
-      url: "https://auth.mozilla.auth0.com/samlp/adMlV8Ud0Z77GLfsaa4fb4oQj8ggf0ws"
-      logo: "expensify.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo', 'team_mozillaonline']
-      display: true
-  - application:
-      name: "GCP Infrastructure"
-      client_id: "uYFDijsgXulJ040Os6VJLRxf0GG30OmC"
-      op: auth0
-      vanity_url: ['/gcp']
-      url: "https://auth.mozilla.auth0.com/samlp/uYFDijsgXulJ040Os6VJLRxf0GG30OmC?RelayState=https://console.cloud.google.com/"
-      logo: "gmail.png"
-      authorized_users: ['gdestuynder@mozilla.com', 'akrug@mozilla.com', 'jmize@mozilla.com']
-      authorized_groups: ['mozilliansorg_gcp-infrastructure-production']
-      display: true
-  - application:
-      name: "Events"
-      client_id: "mwPj23OAUISYVlG5VxW0xI3qSY6OKMON"
-      op: auth0
-      vanity_url: ["/events"]
-      url: "https://splashthat.com/users/oauth/1257"
-      logo: "events.jpg"
-      authorized_users: []
-      authorized_groups: ["everyone"]
-      display: true
-  - application:
-      name: "DataBricks"
-      client_id: "G4vEl4RoedI2Pb7ItlWMNwUUQpsGAmT6"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/G4vEl4RoedI2Pb7ItlWMNwUUQpsGAmT6"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['mozilliansorg_databricks_nda', 'team_moco', 'team_mofo']
-      display: false
-      vanity_url: ['/databricks']
-  - application:
-      name: "Zoom"
-      client_id: "TnqNECyCfoQYd1X7c4xwMF4PMsEfyWPj"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/TnqNECyCfoQYd1X7c4xwMF4PMsEfyWPj"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: false
-      vanity_url: ['/zoom']
-  - application:
-      name: "Atlassian Forge"
-      client_id: "ghFZnGJkgwTIqbs5yDn4vCnrLx3UWmaF"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/ghFZnGJkgwTIqbs5yDn4vCnrLx3UWmaF"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['atlassian_forge']
-      display: false
-  - application:
-      name: "SurveyMonkey"
-      client_id: "LS57OeRbl164EPk39as1TQJ3QbiMuX5M"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/LS57OeRbl164EPk39as1TQJ3QbiMuX5M"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['service_surveymonkey']
-      display: false
-      vanity_url: ['/surveymonkey']
-  - application:
-      name: mozillians.org Verification Client
-      client_id: jijaIzcZmFCDRtV74scMb9lI87MtYNTA
-      url: https://mozillians.org/verify/identity/callback/
-      logo: auth0.png
-      authorized_users: []
-      authorized_groups: ["everyone"]
-      display: false
-      op: auth0
-      AAL: LOW
-  - application:
-      name: mozillians.org Verification Client Staging
-      client_id: t9bMi4eTCPpMp5Y6E1Lu92iVcqU0r1P1
-      url: https://web-mozillians-staging.production.paas.mozilla.community/verify/identity/callback/
-      logo: auth0.png
-      authorized_users: []
-      authorized_groups: ["everyone"]
-      display: false
-      op: auth0
-      AAL: LOW
-  - application:
-      name: https://web-mozillians-staging.production.paas.mozilla.community -- account verification client
-      client_id: HvN5D3R64YNNhvcHKuMKny1O0KJZOOwH
-      url: https://web-mozillians-staging.production.paas.mozilla.community/verify/identity/callback/
-      logo: auth0.png
-      authorized_users: []
-      authorized_groups: ["everyone"]
-      display: false
-      op: auth0-dev
-      AAL: LOW
-  - application:
-      name: "SurveyGizmo"
-      client_id: "tU9fTz20E17hlFVo2DViKtDLABzVxrir"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/tU9fTz20E17hlFVo2DViKtDLABzVxrir"
-      logo: "surveygizmo.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: true
-      vanity_url: ['/surveygizmo']
-  - application:
-      name: "Concur"
-      client_id: "64Ud5s4qJ3GgFZQ2rUG2D4Fod0lYoUu0"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/64Ud5s4qJ3GgFZQ2rUG2D4Fod0lYoUu0"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: false
-      vanity_url: ['/concur']
-  - application:
-      name: "Navex"
-      client_id: "iz2qSHo0lSv2nRZ8V3JnOESX5UR4dcpX"
-      op: auth0
-      url: "https://auth.mozilla.auth0.com/samlp/iz2qSHo0lSv2nRZ8V3JnOESX5UR4dcpX"
-      logo: "auth0.png"
-      authorized_users: []
-      authorized_groups: ['team_moco', 'team_mofo']
-      display: false
-      vanity_url: ['/navex']
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    display: true
+    logo: accountmanager.png
+    name: Account Portal
+    op: auth0
+    url: https://login.mozilla.com/
+    vanity_url:
+    - /accountmanager
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: el46s4SPK4ZOhQBsAjtiDYKFQkXK76xm
+    display: false
+    logo: adaptive_insights.png
+    name: Adaptive Insights
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/el46s4SPK4ZOhQBsAjtiDYKFQkXK76xm
+    vanity_url:
+    - /adaptive
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: 9F55B8e5VmFl4lCgYObnA1TkyRFTxQ9M
+    display: false
+    logo: adobe-sign.png
+    name: Adobe EchoSign
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/9F55B8e5VmFl4lCgYObnA1TkyRFTxQ9M
+    vanity_url:
+    - /echosign
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: 7euXeq96glWUS85bwDRCCs10xKGY93t0
+    display: true
+    logo: airmo.png
+    name: Air Mozilla
+    op: auth0
+    url: https://onlinexperiences.com/scripts/Server.nxp?LASCmd=L:0&AI=1&InitialDisplay=1&ClientBrowser=0&ShowKey=44908
+    vanity_url:
+    - /airmo
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: nV1rnMMkB4uX9IewNOCitqy8NoyXVHlM
+    display: true
+    logo: legacy-airmo.png
+    name: Air Mozilla (Legacy)
+    op: auth0
+    url: https://air.mozilla.org
+    vanity_url:
+    - /legacy-airmo
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    - team_mozillajapan
+    - team_mozillaonline
+    - moc_service_accounts
+    authorized_users:
+    - moc+servicenow@mozilla.com
+    - moc-sso-monitoring@mozilla.com
+    client_id: ql6V6DHXglhTCq9qe6DPdV3eAW2da44F
+    display: true
+    logo: amplitude.png
+    name: Amplitude
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/ql6V6DHXglhTCq9qe6DPdV3eAW2da44F
+    vanity_url:
+    - /amplitude
+- application:
+    authorized_groups:
+    - team_moco
+    authorized_users: []
+    client_id: xAJuHbCa1v0mPp72QMm88hYA2dFEvSy5
+    display: false
+    logo: anaplan.png
+    name: Anaplan
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/xAJuHbCa1v0mPp72QMm88hYA2dFEvSy5
+    vanity_url:
+    - /anaplan
+- application:
+    authorized_groups:
+    - team_opsec
+    authorized_users: []
+    client_id: snpYGrMjpcnNlz7FlXxgFs9ok7IRz83g
+    display: true
+    logo: asap.png
+    name: ASAP (AWS Security Auditing Platform)
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/snpYGrMjpcnNlz7FlXxgFs9ok7IRz83g
+- application:
+    authorized_groups:
+    - service_basket
+    authorized_users: []
+    client_id: 14G95j0WAteSbDicn75gsZvRPXN6bkQm
+    display: true
+    logo: basket.png
+    name: Basket
+    op: auth0
+    url: https://basket-admin.us-west.moz.works/oidc/authenticate/
+- application:
+    authorized_groups:
+    - service_basket
+    authorized_users: []
+    client_id: xZsLG6eg9XjFm5vHKNi4pgE12gfpQM1p
+    display: true
+    logo: basket.png
+    name: Basket Dev
+    op: auth0
+    url: https://basket-dev.allizom.org/oidc/authenticate/
+- application:
+    authorized_groups:
+    - service_basket
+    authorized_users: []
+    client_id: vBgSD2axkzQ6UnC20AFTko0oRr3elwa6
+    display: true
+    logo: basket.png
+    name: Basket Staging
+    op: auth0
+    url: https://basket-admin-stage.us-west.moz.works/oidc/authenticate/
+- application:
+    authorized_groups:
+    - service_beckon
+    authorized_users: []
+    client_id: ZtHVNezP0k2vuZnAg5zbRuFTz76vrXpZ
+    display: true
+    logo: beckon.png
+    name: Beckon
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/ZtHVNezP0k2vuZnAg5zbRuFTz76vrXpZ
+    vanity_url:
+    - /beckon
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: IU80mVpKPtIZyUZtya9ZnSTs6fKLt3JO
+    display: true
+    logo: biztera.png
+    name: Casa
+    op: auth0
+    url: https://biztera.com/mozilla
+    vanity_url:
+    - /casa
+- application:
+    authorized_groups:
+    - cloudhealth-power
+    - cloudhealth-standard
+    - cloudhealth-administrator
+    - cloudhealth-enhanced-power-user
+    - cloudhealth-enhanced-standard-user
+    authorized_users: []
+    client_id: kvfwYzMi40o93JJuuzfdwzeXnnJghgwN
+    display: true
+    logo: cloudhealth.png
+    name: CloudHealth
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/kvfwYzMi40o93JJuuzfdwzeXnnJghgwN
+    vanity_url:
+    - /cloudhealth
+- application:
+    authorized_groups:
+    - mozilliansorg_nda
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: BbenZUhB0TUVZnAtYvysfvpZKNHby4JX
+    display: true
+    logo: bitergia.png
+    name: Community Analytics
+    op: auth0
+    url: https://analytics.mozilla.community
+    vanity_url:
+    - /analytics
+- application:
+    authorized_groups:
+    - aws_consolidatedbilling_read_only
+    authorized_users: []
+    client_id: koX1ze40wpoUovVV3RA7K79uTlxpbZFp
+    display: true
+    logo: aws.png
+    name: Consolidated Billing AWS
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/koX1ze40wpoUovVV3RA7K79uTlxpbZFp
+- application:
+    AAL: LOW
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: rehgg9cqVmHJbHw3jPYUzoU5BYYBH6XL
+    display: true
+    logo: discourse.png
+    name: Discourse
+    op: auth0
+    url: https://discourse.mozilla.org/auth/auth0
+    vanity_url:
+    - /discourse
+- application:
+    AAL: LOW
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: RqUns8zD5oTsEsjTKAUMhF55sLfuQsGv
+    display: false
+    logo: discourse.png
+    name: Discourse Staging
+    op: auth0-dev
+    url: https://discourse-staging.production.paas.mozilla.community/auth/auth0
+    vanity_url:
+    - /discourse-stage
+- application:
+    AAL: LOW
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: 3LIXec4tKVr6SltYFYUYsE0GIw0Jm2T0
+    display: false
+    logo: discourse.png
+    name: Discourse-Dev
+    op: auth0-dev
+    url: https://discourse.allizom.org/auth/auth0
+    vanity_url:
+    - /discourse-dev
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: 72Q4MlsbMzRo5Sij6y5JPDAiyGcyDKB2
+    display: false
+    logo: domo.png
+    name: Domo
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/72Q4MlsbMzRo5Sij6y5JPDAiyGcyDKB2
+    vanity_url:
+    - /domo
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: GmGXMS6RJt3ZvabfTjx16B97pETlnUxd
+    display: false
+    logo: auth0.png
+    name: DXR
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/GmGXMS6RJt3ZvabfTjx16B97pETlnUxd
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: kNsY9QiOy7pSUjiordq7WixztBPCepuD
+    display: false
+    logo: auth0.png
+    name: DXR-stage
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/kNsY9QiOy7pSUjiordq7WixztBPCepuD
+- application:
+    authorized_groups:
+    - egencia_us
+    - egencia_ca
+    authorized_users: []
+    display: true
+    logo: egencia.png
+    name: Egencia
+    op: auth0
+    url: https://www.egencia.com/pub/agent.dll?qscr=vain&vain=mozilla
+    vanity_url:
+    - /egencia
+- application:
+    authorized_groups:
+    - egencia_uk
+    authorized_users: []
+    display: true
+    logo: egencia.png
+    name: Egencia (UK)
+    op: auth0
+    url: https://www.egencia.com/auth/v1/login?call-back-url=aHR0cDovL21vemlsbGEuZWdlbmNpYS5jby51ay9hcHA%2Fc2VydmljZT1leHRlcm5hbCZwYWdlPUxvZ2luJm1vZGU9Zm9ybSZtYXJrZXQ9R0I%3D
+    vanity_url:
+    - /egenciauk
+- application:
+    authorized_groups:
+    - egencia_ca
+    authorized_users: []
+    display: false
+    logo: egencia.png
+    name: Egencia (CA)
+    op: auth0
+    url: http://www.egencia.ca/pub/agent.dll?qscr=vain&amp;vain=mozilla
+    vanity_url:
+    - /egenciaca
+- application:
+    authorized_groups:
+    - egencia_apac
+    authorized_users: []
+    display: true
+    logo: egencia.png
+    name: Egencia (APAC)
+    op: auth0
+    url: https://www.egencia.com/auth/v1/login?call-back-url=aHR0cDovL21vemlsbGEuZWdlbmNpYS5jb20uc2cvYXBwP3NlcnZpY2U9ZXh0ZXJuYWwmcGFnZT1Mb2dpbiZtb2RlPWZvcm0mbWFya2V0PVNH
+    vanity_url:
+    - /egenciaapac
+- application:
+    authorized_groups:
+    - egencia_de
+    authorized_users: []
+    display: true
+    logo: egencia.png
+    name: Egencia (DE)
+    op: auth0
+    url: https://www.egencia.com/auth/v1/login?call-back-url=aHR0cDovL21vemlsbGEuZWdlbmNpYS5kZS9hcHA%2Fc2VydmljZT1leHRlcm5hbCZwYWdlPUxvZ2luJm1vZGU9Zm9ybSZtYXJrZXQ9REU%3D
+    vanity_url:
+    - /egenciade
+- application:
+    authorized_groups:
+    - egencia_fr
+    authorized_users: []
+    display: true
+    logo: egencia.png
+    name: Egencia (FR)
+    op: auth0
+    url: https://www.egencia.com/auth/v1/login?call-back-url=aHR0cDovL21vemlsbGEuZWdlbmNpYS5mci9hcHA%2Fc2VydmljZT1leHRlcm5hbCZwYWdlPUxvZ2luJm1vZGU9Zm9ybSZtYXJrZXQ9RlI%3D
+    vanity_url:
+    - /egenciafr
+- application:
+    authorized_groups:
+    - service_eventboard
+    authorized_users: []
+    client_id: DhBV04HLs6H8OeTHOlodz0LtkyY7VTU0
+    display: false
+    logo: eventboard.png
+    name: EventBoard
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/DhBV04HLs6H8OeTHOlodz0LtkyY7VTU0
+    vanity_url:
+    - /eventboard
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    - team_mozillajapan
+    - team_mozillaonline
+    authorized_users: []
+    client_id: Qxc2EI4g0NymUBvfFKpuwPdSzJZX5TEN
+    display: false
+    logo: exacttarget.png
+    name: Marketing Cloud
+    op: auth0
+    url: https://auth.s1.exacttarget.com/sso/f56e153c30265a772451342d7a59223f4d2c29351a2c305028757a572228
+    vanity_url:
+    - /marketingcloud
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    - team_mozillajapan
+    - team_mozillaonline
+    - gsuite_shared_accounts
+    - moc_service_accounts
+    authorized_users:
+    - moc+servicenow@mozilla.com
+    - moc-sso-monitoring@mozilla.com
+    client_id: smKTjsVVxUJDEkjIftOsP0bop2NWjysa
+    display: true
+    logo: gmail.png
+    name: Gmail
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/smKTjsVVxUJDEkjIftOsP0bop2NWjysa?RelayState=https://mail.google.com/
+    vanity_url:
+    - /gmail
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    - team_mozillajapan
+    - team_mozillaonline
+    - gsuite_shared_accounts
+    - moc_service_accounts
+    authorized_users: []
+    client_id: smKTjsVVxUJDEkjIftOsP0bop2NWjysa
+    display: true
+    logo: gcal.png
+    name: Google Calendar
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/smKTjsVVxUJDEkjIftOsP0bop2NWjysa?RelayState=https://calendar.google.com/
+    vanity_url:
+    - /gcalendar
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    - team_mozillajapan
+    - team_mozillaonline
+    - gsuite_shared_accounts
+    - moc_service_accounts
+    authorized_users: []
+    client_id: smKTjsVVxUJDEkjIftOsP0bop2NWjysa
+    display: true
+    logo: gdrive.png
+    name: Google Drive
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/smKTjsVVxUJDEkjIftOsP0bop2NWjysa?RelayState=https://drive.google.com/
+    vanity_url:
+    - /gdrive
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: TGlmvMW4kvEz99CRnuGnNTfxku0QNn8e
+    display: true
+    logo: greenhouse.png
+    name: Greenhouse
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/TGlmvMW4kvEz99CRnuGnNTfxku0QNn8e
+    vanity_url:
+    - /greenhouse
+- application:
+    authorized_groups:
+    - mozilliansorg_heroku-members
+    authorized_users: []
+    client_id: KOyQ76xjXqtsPgt4ci4bThpIz3a1396E
+    display: true
+    logo: auth0.png
+    name: Heroku
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/KOyQ76xjXqtsPgt4ci4bThpIz3a1396E
+    vanity_url:
+    - /heroku
+- application:
+    authorized_groups:
+    - IntranetWiki
+    authorized_users: []
+    client_id: 3TMLWJb8KIbjB1S3HeyjDm0ns192BTdZ
+    display: false
+    logo: auth0.png
+    name: Intranet
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/3TMLWJb8KIbjB1S3HeyjDm0ns192BTdZ
+- application:
+    authorized_groups:
+    - IntranetWiki
+    authorized_users: []
+    client_id: 0tHkuAC17kDkFip4szjsLvWHlXGJSjwc
+    display: false
+    logo: auth0.png
+    name: Intranet-stage
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/0tHkuAC17kDkFip4szjsLvWHlXGJSjwc
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: f4SlPDVeVcWBChrAvH8uLuEYyt0aW916
+    display: false
+    logo: auth0.png
+    name: iplimitirc
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/f4SlPDVeVcWBChrAvH8uLuEYyt0aW916
+- application:
+    authorized_groups:
+    - irccloud
+    authorized_users: []
+    client_id: D4hqwOVDV2UUJBW2FwD1RxnguPm14Mv3
+    display: true
+    logo: irccloud.png
+    name: IRCCloud
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/D4hqwOVDV2UUJBW2FwD1RxnguPm14Mv3
+    vanity_url:
+    - /irccloud
+- application:
+    authorized_groups:
+    - service_lucidchart
+    authorized_users: []
+    client_id: 80JNexePA737rSLhBAABqIvMJTEAn11u
+    display: true
+    logo: lucidchart.png
+    name: LucidChart
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/80JNexePA737rSLhBAABqIvMJTEAn11u
+    vanity_url:
+    - /lucidchart
+- application:
+    authorized_groups:
+    - IntranetWiki
+    - GuestWiki
+    - moc_service_accounts
+    authorized_users:
+    - moc+servicenow@mozilla.com
+    - moc-sso-monitoring@mozilla.com
+    client_id: LVjFyOpHUdAJTLkTmDnUADnQmUKOWXO2
+    display: true
+    logo: mana.png
+    name: Mana
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/LVjFyOpHUdAJTLkTmDnUADnQmUKOWXO2
+    vanity_url:
+    - /mana
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    - team_mozillajapan
+    - team_mozillaonline
+    - moc_service_accounts
+    authorized_users: []
+    client_id: zXilPvZm4Vy2c2YcpMslENEtGXHWc5Rq
+    display: true
+    logo: jira.png
+    name: Jira
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/zXilPvZm4Vy2c2YcpMslENEtGXHWc5Rq
+    vanity_url:
+    - /jira
+- application:
+    authorized_groups:
+    - service_mana_stage
+    authorized_users: []
+    client_id: IuWFSguzDAqbTT4qdtmABNdCVayuCWy5
+    display: false
+    logo: mana.png
+    name: Mana Stage
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/IuWFSguzDAqbTT4qdtmABNdCVayuCWy5
+- application:
+    authorized_groups:
+    - mozilliansorg_nda
+    - team_moco
+    - team_mofo
+    - team_mozillajapan
+    - team_mozillaonline
+    - moc_service_accounts
+    authorized_users:
+    - moc+servicenow@mozilla.com
+    - moc-sso-monitoring@mozilla.com
+    client_id: wAXfZ9Z2JS3gRMbY6G3uxzUZTNO1YPwh
+    display: true
+    logo: mdc.png
+    name: Data Collective
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/wAXfZ9Z2JS3gRMbY6G3uxzUZTNO1YPwh?RelayState=https://www.mozdatacollective.com
+    vanity_url:
+    - /mdc
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    display: true
+    logo: mdn.png
+    name: MDN Web Docs
+    op: auth0
+    url: https://developer.mozilla.org/
+    vanity_url:
+    - /mdn
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: nPr8QRo0dLxM3RRHwIXRSvhmOSPDvNr4
+    display: true
+    logo: moderator.png
+    name: Moderator
+    op: auth0
+    url: https://moderator.mozilla.org/oidc/authenticate/
+    vanity_url:
+    - /moderator
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: HdfEiM1SZibaQnOYTxLoMdxSh4a6ZKD3
+    display: true
+    logo: mozillians.png
+    name: Mozillians
+    op: auth0
+    url: https://mozillians.org/oidc/authenticate/
+    vanity_url:
+    - /mozillians
+- application:
+    AAL: LOW
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: T2tB7Ss8It7PKrw3ijazoXu9PgZniLPD
+    display: false
+    logo: mozillians.png
+    name: Mozillians Staging
+    op: auth0
+    url: https://web-mozillians-staging.production.paas.mozilla.community/oidc/authenticate/
+- application:
+    authorized_groups:
+    - service_nucleus_prod
+    authorized_users: []
+    client_id: a6cidU6mSbciFAjy4uRQeeuFHIsLIWgg
+    display: true
+    logo: nucleus.png
+    name: Nucleus
+    op: auth0
+    url: https://nucleus.mozilla.org/oidc/authenticate/
+- application:
+    authorized_groups:
+    - service_nucleus_dev
+    authorized_users: []
+    client_id: grGFAm6XbCYn3feUbyg5i9M6eyQHuhe6
+    display: true
+    logo: nucleus.png
+    name: Nucleus Dev
+    op: auth0
+    url: https://nucleus-dev.frankfurt.moz.works/oidc/authenticate/
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: 4HNLHcA7ZSNVWSJVBk9yVxq06WRquN2L
+    display: false
+    logo: auth0.png
+    name: Optimizely
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/4HNLHcA7ZSNVWSJVBk9yVxq06WRquN2L
+    vanity_url:
+    - /optimizely
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: Gav1XmmrpBxts0zeDPOSfGesVrTt044k
+    display: false
+    logo: pagerduty.png
+    name: PagerDuty
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/Gav1XmmrpBxts0zeDPOSfGesVrTt044k
+    vanity_url:
+    - /pagerduty
+- application:
+    authorized_groups:
+    - phonebook_access
+    authorized_users: []
+    client_id: K7vKewjQHKe45mmOo5cRae6yyOvnmg74
+    display: true
+    logo: phonebook.png
+    name: Phonebook
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/K7vKewjQHKe45mmOo5cRae6yyOvnmg74
+    vanity_url:
+    - /phonebook
+- application:
+    authorized_groups:
+    - phonebook_access
+    authorized_users: []
+    client_id: 00fgOKsjo530sIxfhsved8jyTjAD0av2
+    display: false
+    logo: phonebook.png
+    name: Phonebook Stage
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/00fgOKsjo530sIxfhsved8jyTjAD0av2
+    vanity_url:
+    - /phonebook-stage
+- application:
+    authorized_groups:
+    - ldapAdmins
+    authorized_users: []
+    client_id: 0w4E1e2qbcA44oQKfYiUF167pc2l1Lud
+    display: true
+    logo: auth0.png
+    name: PHPLDAPAdmin
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/0w4E1e2qbcA44oQKfYiUF167pc2l1Lud?RelayState=https://ldapadmin1.private.scl3.mozilla.com/phpldapadmin/
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: DBRlLjVEUbw1yWrUYAHNYl22KBkKAjql
+    display: true
+    logo: plansource.png
+    name: PlanSource Benefits
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/DBRlLjVEUbw1yWrUYAHNYl22KBkKAjql?RelayState=https://benefits.plansource.com/sso/employee/saml2/post/d4f3574247aa2707
+    vanity_url:
+    - /plansource
+- application:
+    authorized_groups:
+    - service_productplan
+    authorized_users: []
+    client_id: Ky8RbBLJ36PhlagJMT46ru6DWW8AK451
+    display: true
+    logo: productplan.png
+    name: ProductPlan
+    op: auth0
+    url: https://desktop.pingone.com/mozilla/url?source=application&url=https%3A%2F%2Fsso.connect.pingidentity.com%2Fsso%2Fsp%2Finitsso%3Fsaasid%3D72a035e2-0939-4685-aa8a-8c731729298b%26idpid%3Dmozilla.com&title=IDP%20Connection&applicationtype=APPLICATION_DEFAULT&saasid=72a035e2-0939-4685-aa8a-8c731729298b&newDock=true
+    vanity_url:
+    - /productplan
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: zwpij4T2QTt7QdbmdpkAG5FQgoeSRbyB
+    display: true
+    logo: reps.png
+    name: Reps
+    op: auth0
+    url: https://reps.mozilla.org/oidc/authenticate/
+    vanity_url:
+    - /reps
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: 3rbiX5U5EZZFf9tvYpOdoUxJ6A2TnH2q
+    display: true
+    logo: riskheatmap.png
+    name: RiskHeatMap
+    op: auth0
+    url: https://riskheatmap.security.mozilla.org/
+    vanity_url:
+    - /riskheatmap
+- application:
+    authorized_groups:
+    - SecurityAssuranceOpsec
+    authorized_users: []
+    client_id: 5vVAvF2lo36Nj576GqZTTsbXzZ1AH21L
+    display: true
+    logo: riskheatmap.png
+    name: RiskHeatMap (Dev)
+    op: auth0
+    url: https://riskheatmap.security.allizom.org/
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: ByW5ChOPpsQaQFLcAuZBbtjFrh67uBgt
+    display: false
+    logo: salescloud.png
+    name: SalesCloud
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/ByW5ChOPpsQaQFLcAuZBbtjFrh67uBgt
+    vanity_url:
+    - /salescloud
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: 54KBW3ESzKFfQws77PCXziJnPt0dYHE0
+    display: false
+    logo: salescloud.png
+    name: Salesforce.com Dev Sandbox
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/54KBW3ESzKFfQws77PCXziJnPt0dYHE0
+- application:
+    authorized_groups:
+    - team_moco
+    - SecurityWiki
+    authorized_users: []
+    client_id: js47vk5Ncr7Rv4SUyIyVBRXvlRSLrHVG
+    display: false
+    logo: auth0.png
+    name: Securitywiki
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/js47vk5Ncr7Rv4SUyIyVBRXvlRSLrHVG
+- application:
+    authorized_groups:
+    - team_moco
+    - SecurityWiki
+    authorized_users: []
+    client_id: OWVEwzt059vjws6mkQgGeqJChA4dBI70
+    display: false
+    logo: auth0.png
+    name: Securitywiki-stage
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/OWVEwzt059vjws6mkQgGeqJChA4dBI70
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: Hy16dlY3Kmw373jWKVeMGulVUTt1y1KX
+    display: false
+    logo: servicenow.png
+    name: ServiceNow - Dev
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/Hy16dlY3Kmw373jWKVeMGulVUTt1y1KX
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: DIx9YBxmtAWGGSV6nc21wSEXuymRSvY9
+    display: false
+    logo: servicenow.png
+    name: ServiceNow - Stage
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/DIx9YBxmtAWGGSV6nc21wSEXuymRSvY9
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: dPlqnxe8phbjbhm80W1Ry8SzSGS3ijuh
+    display: false
+    logo: servicenow.png
+    name: ServiceNow - Test
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/dPlqnxe8phbjbhm80W1Ry8SzSGS3ijuh
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    - moc_service_accounts
+    authorized_users:
+    - moc+servicenow@mozilla.com
+    - moc-sso-monitoring@mozilla.com
+    client_id: axoW08Nny1HXe0qcP0416YGrmYtfgdTQ
+    display: false
+    logo: servicenow.png
+    name: ServiceNow - Upgrade
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/axoW08Nny1HXe0qcP0416YGrmYtfgdTQ
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: l094SuNKnntJaVwkUU2tWxOsEtx5h3Oo
+    display: true
+    logo: smartsheet.png
+    name: Smartsheet
+    op: auth0
+    url: https://app.smartsheet.com/b/orgsso/C5AE787951B226D893639096D1863484
+    vanity_url:
+    - /smartsheet
+    - /smartsheets
+- application:
+    authorized_groups:
+    - service_snippets
+    authorized_users: []
+    client_id: A7GAcuN9gE9x3H186dKQgzS3jsV9Qmgp
+    display: true
+    logo: snippets.png
+    name: Snippets
+    op: auth0
+    url: https://snippets-admin.us-west.moz.works/oidc/authenticate/
+- application:
+    authorized_groups:
+    - netops
+    - splunk_admin
+    - hris_dept_it
+    authorized_users: []
+    client_id: EUmKs3owmNdeDWxZ4CJIeSGM5ez3Suav
+    display: true
+    logo: splunk.png
+    name: Splunk
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/EUmKs3owmNdeDWxZ4CJIeSGM5ez3Suav
+    vanity_url:
+    - /splunk
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: dc50KcxGnMPBOSlE5QLYaDRmfrO7oXhq
+    display: true
+    logo: statuspage.png
+    name: StatusPage
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/dc50KcxGnMPBOSlE5QLYaDRmfrO7oXhq
+    vanity_url:
+    - /statuspage
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: Wz5oO6y8oJ35Yq1B91aC4pkwlXdes7jR
+    display: false
+    logo: auth0.png
+    name: support.allizom.org:admin
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/Wz5oO6y8oJ35Yq1B91aC4pkwlXdes7jR
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: a145ph7ZPSz97z8QkiuP1iId6MFPXXUH
+    display: false
+    logo: auth0.png
+    name: support.mozilla.org:admin
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/a145ph7ZPSz97z8QkiuP1iId6MFPXXUH
+- application:
+    authorized_groups:
+    - tableau_users
+    - moc_service_accounts
+    authorized_users: []
+    client_id: J6oAK91WCqBLQjpG2v6U3yKyoN9FL13Q
+    display: true
+    logo: tableau.png
+    name: Tableau (dataviz.mozilla.org)
+    op: auth0
+    url: https://dataviz.mozilla.org/
+    vanity_url:
+    - /tableau
+- application:
+    authorized_groups:
+    - tableau_users
+    - moc_service_accounts
+    authorized_users: []
+    client_id: P42x7zxtymbHLvBysEustI6nJWZmMmtq
+    display: false
+    logo: tableau.png
+    name: Tableau-staging
+    op: auth0
+    url: https://dataviz.allizom.org/
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: 1db5KNoLN5rLZukvLouWwVouPkbztyso
+    display: false
+    logo: taskcluster.png
+    name: TaskCluster
+    op: auth0
+    url: https://login.taskcluster.net
+    vanity_url:
+    - /taskcluster
+- application:
+    authorized_groups:
+    - aws_consolidatedbilling_temporary_admin
+    authorized_users: []
+    client_id: XA2fOQITX6rGNHy8DI3KuuRdccaKwsM6
+    display: true
+    logo: aws.png
+    name: Temp Admin - Consolidated Billing AWS
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/XA2fOQITX6rGNHy8DI3KuuRdccaKwsM6
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    - team_mozillajapan
+    - team_mozillaonline
+    - moc_service_accounts
+    authorized_users:
+    - moc+servicenow@mozilla.com
+    - moc-sso-monitoring@mozilla.com
+    client_id: 5gtZrLu2eyAapp1BgQsF11rhdPNt2lGP
+    display: true
+    logo: thehub.png
+    name: The Hub
+    op: auth0
+    url: https://mozilla.service-now.com/
+    vanity_url:
+    - /thehub
+    - /servicenow
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: q8fZZFfGEmSB2c5uSI8hOkKdDGXnlo5z
+    display: true
+    logo: treeherder.png
+    name: Treeherder
+    op: auth0
+    url: https://treeherder.mozilla.org
+    vanity_url:
+    - /treeherder
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: Hypn042D0cqtqET33nRrnqOwAcIXOqx6
+    display: true
+    logo: workday.png
+    name: Workday
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/Hypn042D0cqtqET33nRrnqOwAcIXOqx6
+    vanity_url:
+    - /workday
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: kyeMyPALPK84A58vlOnb7lrCzAIFJapP
+    display: false
+    logo: workday.png
+    name: Workday - Preview
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/kyeMyPALPK84A58vlOnb7lrCzAIFJapP
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: pRwf1AWvIO5t4zyMsF8R18wtt1jfLp5o
+    display: false
+    logo: workday.png
+    name: Workday - Sandbox
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/pRwf1AWvIO5t4zyMsF8R18wtt1jfLp5o
+- application:
+    authorized_groups:
+    - mozilliansorg_slack-access
+    - team_moco
+    - team_mofo
+    - team_mozillaonline
+    - hris_is_staff
+    authorized_users: []
+    client_id: WXVdgVoCca11OtpGlK8Ir3pR9CBAlSA5
+    display: true
+    logo: slack.png
+    name: Slack
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/WXVdgVoCca11OtpGlK8Ir3pR9CBAlSA5
+    vanity_url:
+    - /slack
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: meBoR5vlD0kK0qeUXshNjOB1PbGKjsro
+    display: false
+    logo: auth0.png
+    name: Convercent
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/meBoR5vlD0kK0qeUXshNjOB1PbGKjsro?RelayState=https://app.convercent.com/
+    vanity_url:
+    - /convercent
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: j8FN0DB6RwrlfLhX4opVAZ2tDYbBiMMU
+    display: false
+    logo: auth0.png
+    name: Convercent - Community
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/j8FN0DB6RwrlfLhX4opVAZ2tDYbBiMMU?RelayState=https://app.convercent.com/
+    vanity_url:
+    - /convercentcommunity
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: i55sTCbmgUTkvHPW3SDueKlKbtPj5iRF
+    display: false
+    logo: auth0.png
+    name: OneTrust
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/i55sTCbmgUTkvHPW3SDueKlKbtPj5iRF
+- application:
+    authorized_groups:
+    - netops
+    - team_infra
+    - team_moc
+    - team_opsec
+    - team_avops
+    - team_relops
+    - vpn_panorama
+    authorized_users: []
+    client_id: z5zWsArYQgI63CEjMMtODh0DFtDr5oSz
+    display: true
+    logo: paloalto.png
+    name: Palo Alto Networks Panorama
+    op: auth0
+    url: https://panorama.mozilla.net/
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    - cloudops_atmo_access
+    authorized_users: []
+    client_id: 6GDrRrIYZuRRKLXXbucm4bO0eafK0AKN
+    display: false
+    logo: auth0.png
+    name: Analysis Telemetry
+    op: auth0
+    url: https://analysis.telemetry.mozilla.org/
+- application:
+    authorized_groups:
+    - netops
+    - relops
+    - team_opsec
+    - team_moc
+    authorized_users: []
+    client_id: GWhjnB7egp5hDryXeoD7OJRjHshWWQap
+    display: false
+    logo: auth0.png
+    name: Netops Gitlab
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/GWhjnB7egp5hDryXeoD7OJRjHshWWQap
+- application:
+    authorized_groups:
+    - cis_whitelist
+    - team_moco
+    authorized_users: []
+    client_id: BRMXeyw2avAOj7GgBD4SuIHxopb0yZJP
+    display: false
+    logo: auth0.png
+    name: Apache Test RP
+    op: auth0-dev
+    url: https://apache.testrp.security.allizom.org/
+- application:
+    AAL: LOW
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: FeqjZfpOqMIkcGKkd2fDjpnm5oSsOOZ2
+    display: false
+    logo: auth0.png
+    name: AAL Low Test RP
+    op: auth0-dev
+    url: https://aai-low-social-ldap-pwless.testrp.security.allizom.org/
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: mc1l0G4sJI2eQfdWxqgVNcRAD9EAgHib
+    display: false
+    logo: auth0.png
+    name: SSO Dashboard (Dev)
+    op: auth0-dev
+    url: https://sso.allizom.org/
+- application:
+    authorized_groups:
+    - team_moco
+    authorized_users: []
+    client_id: Q3z1fjeoZhGyws1IXDUc6rHdcYNpxTv8
+    display: false
+    logo: auth0.png
+    name: PTO
+    op: auth0
+    url: https://pto.mozilla.org/
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: VjJFa4EeFWd29pMnhyAk7AkGW2ids5UX
+    display: false
+    logo: auth0.png
+    name: Desk
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/VjJFa4EeFWd29pMnhyAk7AkGW2ids5UX
+    vanity_url:
+    - /desk
+- application:
+    authorized_groups:
+    - hris_costcenter_1420
+    - vpn_opsec_mozdef
+    - team_moc
+    - team_secops
+    authorized_users: []
+    client_id: PSCl3uIPg5IT2GaiOcAIJprYK7iBK32r
+    display: true
+    expire_access_when_unused_after: 7776000
+    logo: mozdef.png
+    name: Mozilla Defense Platform
+    op: auth0
+    url: https://mozdef.infosec.mozilla.org/
+- application:
+    authorized_groups:
+    - hris_costcenter_1420
+    - vpn_opsec_mozdef
+    authorized_users: []
+    client_id: Dj0vncaBmaHn1zxzRc1cuFQIBxD0YSGp
+    display: false
+    expire_access_when_unused_after: 7776000
+    logo: mozdef.png
+    name: Mozilla Defense Platform QA
+    op: auth0
+    url: https://mozdefqa1.private.mdc1.mozilla.com/
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: t1KWNQt71oskeip2KCu9j0KhwJJbBkig
+    display: false
+    logo: auth0.png
+    name: Xmatters Stage
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/t1KWNQt71oskeip2KCu9j0KhwJJbBkig
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: uMkOuQX8LGTxAyYIiX4eLoc4hl0pWSJt
+    display: false
+    logo: auth0.png
+    name: Xmatters
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/uMkOuQX8LGTxAyYIiX4eLoc4hl0pWSJt
+- application:
+    authorized_groups:
+    - mozilliansorg_mozilla-iam-aws-access
+    authorized_users: []
+    client_id: 2lTZtlpqx4bslng167l1BBqTMusCAJkZ
+    display: false
+    logo: auth0.png
+    name: IAM AWS Account
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/2lTZtlpqx4bslng167l1BBqTMusCAJkZ
+    vanity_url:
+    - /iam-infra
+- application:
+    authorized_groups:
+    - mozilliansorg_mozilla-iam-aws-access
+    authorized_users: []
+    client_id: nlE73wPPuOaN0wAYKWY6QD3VcjUStehZ
+    display: false
+    logo: auth0.png
+    name: IAM Grafana
+    op: auth0
+    url: https://grafana.infra.iam.mozilla.com/login/generic_oauth
+    vanity_url:
+    - /iam-grafana
+- application:
+    authorized_groups:
+    - mozilliansorg_nda
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: yCKLKXrrkigZwoQ9d6xzmE5NuvVW0oBj
+    display: false
+    logo: auth0.png
+    name: Box
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/yCKLKXrrkigZwoQ9d6xzmE5NuvVW0oBj
+    vanity_url:
+    - /box
+- application:
+    authorized_groups:
+    - service_airtable
+    authorized_users: []
+    client_id: mKlNDH9c7JKO1Rh3HtGXdTtLntTlHefx
+    display: false
+    logo: auth0.png
+    name: AirTable
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/mKlNDH9c7JKO1Rh3HtGXdTtLntTlHefx
+    vanity_url:
+    - /airtable
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: ChKEapjEYTPx0T1b5QP01WhAeP8ymRJ7
+    display: false
+    logo: auth0.png
+    name: admin.readitlater.com
+    op: auth0
+    url: https://admin.readitlater.com
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mozillaonline
+    authorized_users: []
+    client_id: 2QnAFjxpltXc2dTkd9QW7nY43dx6xf5a
+    display: true
+    logo: syntrio.png
+    name: Syntrio
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/2QnAFjxpltXc2dTkd9QW7nY43dx6xf5a
+    vanity_url:
+    - /syntrio
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    - team_mozillaonline
+    authorized_users: []
+    display: true
+    logo: expensify.png
+    name: Expensify
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/adMlV8Ud0Z77GLfsaa4fb4oQj8ggf0ws
+    vanity_url:
+    - /expensify
+- application:
+    authorized_groups:
+    - mozilliansorg_gcp-infrastructure-production
+    authorized_users:
+    - gdestuynder@mozilla.com
+    - akrug@mozilla.com
+    - jmize@mozilla.com
+    client_id: uYFDijsgXulJ040Os6VJLRxf0GG30OmC
+    display: true
+    logo: gmail.png
+    name: GCP Infrastructure
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/uYFDijsgXulJ040Os6VJLRxf0GG30OmC?RelayState=https://console.cloud.google.com/
+    vanity_url:
+    - /gcp
+- application:
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: mwPj23OAUISYVlG5VxW0xI3qSY6OKMON
+    display: true
+    logo: events.jpg
+    name: Events
+    op: auth0
+    url: https://splashthat.com/users/oauth/1257
+    vanity_url:
+    - /events
+- application:
+    authorized_groups:
+    - mozilliansorg_databricks_nda
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: G4vEl4RoedI2Pb7ItlWMNwUUQpsGAmT6
+    display: false
+    logo: auth0.png
+    name: DataBricks
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/G4vEl4RoedI2Pb7ItlWMNwUUQpsGAmT6
+    vanity_url:
+    - /databricks
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: TnqNECyCfoQYd1X7c4xwMF4PMsEfyWPj
+    display: false
+    logo: auth0.png
+    name: Zoom
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/TnqNECyCfoQYd1X7c4xwMF4PMsEfyWPj
+    vanity_url:
+    - /zoom
+- application:
+    authorized_groups:
+    - atlassian_forge
+    authorized_users: []
+    client_id: ghFZnGJkgwTIqbs5yDn4vCnrLx3UWmaF
+    display: false
+    logo: auth0.png
+    name: Atlassian Forge
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/ghFZnGJkgwTIqbs5yDn4vCnrLx3UWmaF
+- application:
+    authorized_groups:
+    - service_surveymonkey
+    authorized_users: []
+    client_id: LS57OeRbl164EPk39as1TQJ3QbiMuX5M
+    display: false
+    logo: auth0.png
+    name: SurveyMonkey
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/LS57OeRbl164EPk39as1TQJ3QbiMuX5M
+    vanity_url:
+    - /surveymonkey
+- application:
+    AAL: LOW
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: jijaIzcZmFCDRtV74scMb9lI87MtYNTA
+    display: false
+    logo: auth0.png
+    name: mozillians.org Verification Client
+    op: auth0
+    url: https://mozillians.org/verify/identity/callback/
+- application:
+    AAL: LOW
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: t9bMi4eTCPpMp5Y6E1Lu92iVcqU0r1P1
+    display: false
+    logo: auth0.png
+    name: mozillians.org Verification Client Staging
+    op: auth0
+    url: https://web-mozillians-staging.production.paas.mozilla.community/verify/identity/callback/
+- application:
+    AAL: LOW
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    client_id: HvN5D3R64YNNhvcHKuMKny1O0KJZOOwH
+    display: false
+    logo: auth0.png
+    name: https://web-mozillians-staging.production.paas.mozilla.community -- account
+      verification client
+    op: auth0-dev
+    url: https://web-mozillians-staging.production.paas.mozilla.community/verify/identity/callback/
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: tU9fTz20E17hlFVo2DViKtDLABzVxrir
+    display: true
+    logo: surveygizmo.png
+    name: SurveyGizmo
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/tU9fTz20E17hlFVo2DViKtDLABzVxrir
+    vanity_url:
+    - /surveygizmo
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: 64Ud5s4qJ3GgFZQ2rUG2D4Fod0lYoUu0
+    display: false
+    logo: auth0.png
+    name: Concur
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/64Ud5s4qJ3GgFZQ2rUG2D4Fod0lYoUu0
+    vanity_url:
+    - /concur
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: iz2qSHo0lSv2nRZ8V3JnOESX5UR4dcpX
+    display: false
+    logo: auth0.png
+    name: Navex
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/iz2qSHo0lSv2nRZ8V3JnOESX5UR4dcpX
+    vanity_url:
+    - /navex


### PR DESCRIPTION
* Adds all apps with LDAP-only or with at least passwordless login methods
  to the list

* Adds `AAL=LOW` to all apps which have passwordless already enabled, so
  that it continues functioning with deratcheting enabled

* Adds `everyone` group when no authorized user or groups are present (emulate old functionality)

* Adds `authorized_groups += ['team_moco', 'team_mofo', 'hris_is_staff']` to all clients with LDAP-only so that the LDAP-only
  restriction is still enforced after all login methods are enabled for the
  RP
  NOTE: This list has been re-serialized by PyYAML as this is the output of a
  script which compared entries in Auth0.