### PR TITLE
Update local Developer Portal Auth0 callback URL

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3789,7 +3789,7 @@ apps:
     logo: auth0.png
     name: Developer Portal (local)
     op: auth0
-    url: https://developer-portal-127-0-0-1.nip.io/auth/callback
+    url: http://localhost:8000/auth/callback
 - application:
     authorized_groups:
     - hris_is_staff


### PR DESCRIPTION
The use of a HTTPS url for the local build is currently stuck at PR because of a CI issue (https://github.com/mdn/developer-portal/pull/434).

In the meantime, can we please support plain old "localhost:8000" without HTTPS to unblock local development?