### PR TITLE
Change EIS New Relic group from moco to EIS

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3788,7 +3788,7 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/cuC3NOGPFm58H172NnOypPf1jGQwMoUf
 - application:
       authorized_groups:
-        - team_moco
+        - hris_costcenter_1420
       authorized_users: []
       display: true
       logo: newrelic.png


### PR DESCRIPTION
This will prevent the EIS New Relic tile from showing up on the SSO Dashboard for all of moco (as only EIS can actually access it, everyone else would get an access denied from NewRelic)

Followup to #339