### PR TITLE
Add vanity_url: /pto to the PTO app

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -1190,6 +1190,8 @@ apps:
     name: PTO
     op: auth0
     url: https://pto.mozilla.org/
+    vanity_url:
+    - /pto
 - application:
     authorized_groups:
     - hris_is_staff


### PR DESCRIPTION
As suggested by Andrew on Slack, this is a simple PR to add sso.m.c/pto to the vanity URL set. Per Slack discussion it's added to fNzz rather than Q3z1, though the code seems to imply that it _could_ be added to both without issue.