### PR TITLE
Remove Smartsheet and mozilla.securityeducation.com mozilla.wombatsecurity.com from apps.yml

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -819,20 +819,6 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/axoW08Nny1HXe0qcP0416YGrmYtfgdTQ
 - application:
     authorized_groups:
-    - team_moco
-    - team_mofo
-    authorized_users: []
-    client_id: l094SuNKnntJaVwkUU2tWxOsEtx5h3Oo
-    display: true
-    logo: smartsheet.png
-    name: Smartsheet
-    op: auth0
-    url: https://app.smartsheet.com/b/orgsso/C5AE787951B226D893639096D1863484
-    vanity_url:
-    - /smartsheet
-    - /smartsheets
-- application:
-    authorized_groups:
     - service_snippets
     authorized_users: []
     client_id: A7GAcuN9gE9x3H186dKQgzS3jsV9Qmgp
@@ -3676,21 +3662,6 @@ apps:
     name: Braintree
     op: auth0
     url: https://auth.mozilla.auth0.com/samlp/x7TF6ZtJev4ktoHR4ObWmA9KeqGni6rq
-- application:
-    authorized_groups:
-    - team_moco
-    - team_mofo
-    - team_pocket
-    - team_mozillaonline
-    authorized_users: []
-    client_id: 6RMuGl43VwCGOxvFXoDLDXE3U3yhEtT8
-    display: true
-    logo: securityawarenesstraining.png
-    name: Security Awareness Training
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/6RMuGl43VwCGOxvFXoDLDXE3U3yhEtT8
-    vanity_url:
-    - /securitytraining
 - application:
     AAL: LOW
     authorized_groups:


### PR DESCRIPTION
Deleted Smartsheets and Proofpoint "Security Awareness Training" as smartsheets is EOL and proofpoint is not renewed.