### PR TITLE
Add logo to vouches app

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -579,6 +579,7 @@ apps:
     client_id: HC1FeMf3dVCTnAZbQR08quMylQEUcu60
     display: false
     name: vouches.mozillians.org
+    logo: mozillians.png
     op: auth0
     url: https://vouches.mozillians.org/oidc/authenticate/
 - application:


### PR DESCRIPTION
Without a logo, the build fails.
Choosing mozillians logo because Vouches is part of Mozillians