### PR TITLE
Remove unused apps

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3519,28 +3519,6 @@ apps:
     vanity_url:
     - /matrix
 - application:
-    AAL: LOW
-    authorized_groups:
-    - everyone
-    authorized_users: []
-    client_id: Naob9cwJz8EnGahxCbHURFGuIkpL5fm7
-    display: false
-    logo: auth0.png
-    name: RocketChat IM
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/Naob9cwJz8EnGahxCbHURFGuIkpL5fm7
-- application:
-    AAL: LOW
-    authorized_groups:
-    - everyone
-    authorized_users: []
-    client_id: dkb2y4Ow9L2PQ6V8bxU7Z1SvNuCSxen6
-    display: false
-    logo: auth0.png
-    name: Mattermost IM
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/dkb2y4Ow9L2PQ6V8bxU7Z1SvNuCSxen6
-- application:
     authorized_groups:
     - hris_is_staff
     - team_moco
@@ -4067,3 +4045,4 @@ apps:
     name: experimenter.stage.mozaws.net
     op: auth0
     url: https://stage.experimenter.nonprod.dataops.mozgcp.net/
+


### PR DESCRIPTION
This PR will remove the configuration for Mattermost and RocketChat which are not used.
I'm holding until mhoye confirms I can proceed.

Afterwards, I'll delete the applications in Auth0.