### PR TITLE
Fix tripactions URL

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3979,7 +3979,7 @@ apps:
     logo: tripactions.png
     name: TripActions
     op: auth0
-    url: https://app.tripactions.com/app/user2/auth
+    url: https://auth.mozilla.auth0.com/samlp/i1qBrMjJEdKlTNEVgGwc9P0xFxI9cuD8
     vanity_url:
     - /tripactions
 - application:


### PR DESCRIPTION
The existing URL doesn't log the user in. Replacing it with the login URL
Updates #409