### PR TITLE
Remove team_pocket from apps

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -532,7 +532,6 @@ apps:
     - hris_is_staff
     - team_moco
     - team_mofo
-    - team_pocket
     authorized_users: []
     client_id: 80JNexePA737rSLhBAABqIvMJTEAn11u
     display: false
@@ -1959,7 +1958,6 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_pocket
     authorized_users: []
     client_id: wsvwqDk1Z2zYa6AU4mMT5Dq4H40lfvF2
     display: true
@@ -2058,7 +2056,6 @@ apps:
     - hris_is_staff
     - team_moco
     - team_mofo
-    - team_pocket
     - team_mozillaonline
     authorized_users: []
     client_id: 2dbkrvUJa5gnxGSnMLZ1jflbtrahhrEi
@@ -3453,7 +3450,6 @@ apps:
 - application:
     authorized_groups:
     - team_moco
-    - team_pocket
     authorized_users: []
     client_id: T95l6gp1PoerbniGDm9eMUaUcKiBJVZt
     display: false
@@ -3644,7 +3640,6 @@ apps:
     - hris_is_staff
     - team_moco
     - team_mofo
-    - team_pocket
     authorized_users: []
     client_id: uGQC74llWoyAedpixUDpu8OLCf6GmqlC
     display: false
@@ -3671,7 +3666,6 @@ apps:
     - hris_is_staff
     - team_moco
     - team_mofo
-    - team_pocket
     authorized_users: []
     client_id: 7i1G4gM7zGuIE4h9T6s1Mho1e9P0cxk1
     display: false
@@ -3686,7 +3680,6 @@ apps:
     - hris_is_staff
     - team_moco
     - team_mofo
-    - team_pocket
     authorized_users: []
     client_id: b2ESDyU2mJN5r6Ani52aIWxg0FoudEl8
     display: false
@@ -3710,7 +3703,6 @@ apps:
     - hris_is_staff
     - team_moco
     - team_mofo
-    - team_pocket
     - team_mozillaonline
     authorized_users: []
     client_id: 7HxWt6W66K2QeytVVCeOoWpJxkVExnzz
@@ -3726,7 +3718,6 @@ apps:
     - hris_is_staff
     - team_moco
     - team_mofo
-    - team_pocket
     authorized_users: []
     client_id: wgh8S9GaE7sJ4i0QrAzeMxFXgWZYtB0l
     display: false
@@ -3741,7 +3732,6 @@ apps:
     - hris_is_staff
     - team_moco
     - team_mofo
-    - team_pocket
     authorized_users: []
     client_id: cEWzoPzUcDwk3JhpD9ENtPKMmE7T5QWv
     display: false
@@ -3754,7 +3744,6 @@ apps:
     - team_moco
     - team_mofo
     - team_mozillaonline
-    - team_pocket
     authorized_users: []
     client_id: WlWmEUQ2dmQFQJfKxNx1ZNkAJRKueaR1
     display: false
@@ -3768,7 +3757,6 @@ apps:
     - team_moco
     - team_mofo
     - team_mozillaonline
-    - team_pocket
     authorized_users: []
     client_id: kfax6JBFqyXQcfEEQmEa56np04rm3uYX
     display: false
@@ -3781,7 +3769,6 @@ apps:
     - hris_is_staff
     - team_moco
     - team_mofo
-    - team_pocket
     authorized_users: []
     client_id: NhzqLGjjqXIp3kGoonkTLSO7awPBhWsK
     display: true
@@ -3796,7 +3783,6 @@ apps:
     - hris_is_staff
     - team_moco
     - team_mofo
-    - team_pocket
     authorized_users: []
     client_id: w8hBBYB30b12DqElacIQkFM6V2deEpwz
     display: false
@@ -3809,7 +3795,6 @@ apps:
     - hris_is_staff
     - team_moco
     - team_mofo
-    - team_pocket
     authorized_users: []
     client_id: QdZOeq5zcpS23Ter4Er0hYmG2PjEZ9It
     display: true
@@ -3882,7 +3867,6 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_pocket
     authorized_users: []
     client_id: cEfnJekrSStxxxBascTjNEDAZVUPAIU2
     display: false
@@ -3896,7 +3880,6 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_pocket
     - team_mozillaonline
     authorized_users: []
     client_id: axRGaXPRd5pe60fnEllluSN76MefFX1E


### PR DESCRIPTION
Given that all members of team_pocket are now members of team_moco and the purpose of
the team_pocket group has changed, this commit removes those references to
team_pocket except in cases where it is explicity granting access to only the members