### PR TITLE
Adding jira_cloud_access to groups able to access mozilla-hub.atlassi…

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -589,6 +589,7 @@ apps:
 - application:
     authorized_groups:
     - mozilliansorg_jira_cloud_admins
+    - mozilliansorg_jira_cloud_access
     authorized_users: []
     client_id: TKqD0MP8sDeJAc9QC4f5yp2r9qbx5fcZ
     display: true


### PR DESCRIPTION
…an.net, which also solves for sso access into getpocket.atlassian.net

Signed-off-by: Rob Tucker <rtucker@mozilla.com>