### PR TITLE
[DO NOT MERGE BEFORE 4/19] Make culture amp available to everyone

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3885,6 +3885,7 @@ apps:
     - team_mofo
     - team_mozillaonline
     authorized_users: []
+    client_id: axRGaXPRd5pe60fnEllluSN76MefFX1E
     display: true
     logo: cultureamp.png
     name: Culture Amp

--- a/apps.yml
+++ b/apps.yml
@@ -3885,16 +3885,6 @@ apps:
     - team_mofo
     - team_mozillaonline
     authorized_users: []
-    client_id: axRGaXPRd5pe60fnEllluSN76MefFX1E
-    display: false
-    logo: auth0.png
-    name: Culture Amp (ACL)
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/axRGaXPRd5pe60fnEllluSN76MefFX1E
-- application:
-    authorized_groups:
-    - managers_all
-    authorized_users: []
     display: true
     logo: cultureamp.png
     name: Culture Amp


### PR DESCRIPTION
This deduplicates the culture amp config and makes it visible to all employees as requested in https://bugzilla.mozilla.org/show_bug.cgi?id=1700222