### PR TITLE
Bug 1710783 - Grant MozillaOnline employees access to Figma.

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -406,6 +406,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
+    - team_mozillaonline
     authorized_users: []
     client_id: eaiAVdOLtf2KXZvexyCCViw0154E0U6x
     display: false


### PR DESCRIPTION
This PR was opened per @ForgottenSonata's comment at [bug 1710783](https://bugzilla.mozilla.org/show_bug.cgi?id=1710783#c2).

r?@sciurus 