### PR TITLE
Add application for Kevel [Bug 1713035]

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3454,6 +3454,16 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/T95l6gp1PoerbniGDm9eMUaUcKiBJVZt
 - application:
     authorized_groups:
+    - team_moco
+    authorized_users: []
+    client_id: WQnlYTEc4PYRRK3FT7n3l9VOtew1IDo2
+    display: false
+    logo: auth0.png
+    name: Kevel
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/WQnlYTEc4PYRRK3FT7n3l9VOtew1IDo2
+- application:
+    authorized_groups:
     - team_pocket
     authorized_users: []
     client_id: Nw44gx8sBU2sjVvoIY8Se3solzd9XM8X


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1713035

This PR sets up a new SAML application to supersede the AdZerk application.  Once Kevel applies the SAML metadata to their side and we can verify the SSO works on our side, I will then submit a follow up PR to remove the deprecated AdZerk application.