### PR TITLE
(Do not merge until culture amp finish setup) Add mofo culture amp application [bug 1717822]

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3845,7 +3845,6 @@ apps:
 - application:
     authorized_groups:
     - team_moco
-    - team_mofo
     - team_mozillaonline
     authorized_users: []
     client_id: axRGaXPRd5pe60fnEllluSN76MefFX1E

--- a/apps.yml
+++ b/apps.yml
@@ -3858,6 +3858,18 @@ apps:
     - /cultureamp
 - application:
     authorized_groups:
+    - team_mofo
+    authorized_users: []
+    client_id: 4b1qHRbxLmNLEBgXMi5eYP0sJn5p6q7l
+    display: true
+    logo: cultureamp.png
+    name: Mozilla Foundation Culture Amp
+    op: auth0
+    url: https://mozillafoundation.cultureamp.com/saml/mozillafoundation
+    vanity_url:
+    - /mofo-cultureamp
+- application:
+    authorized_groups:
     - team_opsec
     authorized_users:
     - jclaudius@mozilla.com


### PR DESCRIPTION
This PR adds the Mofo specific culture amp account.  Note: culture amp has not yet configured their side so URL probably won't work until it is.