### PR TITLE
Remove mentoring.mozilla.com

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -646,19 +646,6 @@ apps:
     - /mdn
 - application:
     authorized_groups:
-    - team_moco
-    - team_mofo
-    authorized_users: []
-    client_id: Zoc0rFi7D3iD18MZGeYXsmXmtuToC7SI
-    display: false
-    logo: auth0.png
-    name: Mentoring
-    op: auth0
-    url: https://mentoring.mozilla.com/oidc/authenticate/
-    vanity_url:
-    - /mentoring
-- application:
-    authorized_groups:
     - everyone
     authorized_users: []
     client_id: nPr8QRo0dLxM3RRHwIXRSvhmOSPDvNr4


### PR DESCRIPTION
This is cleanup for an app that has already been decomissioned

https://mozilla-hub.atlassian.net/browse/SE-1771