### PR TITLE
Add lando.devsvcdev.mozaws.net dashboard app - Bug [1720522]

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -2504,6 +2504,18 @@ apps:
     - team_moco
     - team_mofo
     authorized_users: []
+    client_id: 3a6sbM3CfbTQ8YkZ4wW7YpOdNN5NX4Hb
+    display: false
+    logo: auth0.png
+    name: lando.devsvcdev.mozaws.net
+    op: auth0
+    url: https://lando.devsvcdev.mozaws.net/redirect_uri
+- application:
+    authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
+    authorized_users: []
     client_id: 47BCiKGMwpCH5K7IzmJ1DjrHSo82krNs
     display: false
     logo: auth0.png


### PR DESCRIPTION
This PR adds a dashboard application for an existing auth0 app.  It was discovered that the lando staging app had a dashboard app but the dev did not.  This fixes that.

See bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1720522