### PR TITLE
Add the billing user CIS uid to expensify [SE-2440]

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -1382,6 +1382,7 @@ apps:
     - team_mozillaonline
     authorized_users:
     - billing@mozilla.com
+    - ad|Mozilla-LDAP|billing
     display: true
     logo: expensify.png
     name: Expensify


### PR DESCRIPTION
The user can't see the app currently in dashboard, so maybe granting this by CIS id rather than email will work.

Matching by "sub" as well as by "email" is part of the CIS code for the dashboard, and so may be the case for the entire stack. If so, this will be a simple workaround for the problem with the non-human account, until we're able to understand what's wrong.