### PR TITLE
Group certain complicated SSO entries together [SE-2440]

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -916,19 +916,6 @@ apps:
     - /splunk
 - application:
     authorized_groups:
-    - team_moco
-    - team_mofo
-    authorized_users: []
-    client_id: dc50KcxGnMPBOSlE5QLYaDRmfrO7oXhq
-    display: true
-    logo: statuspage.png
-    name: StatusPage
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/dc50KcxGnMPBOSlE5QLYaDRmfrO7oXhq
-    vanity_url:
-    - /statuspage
-- application:
-    authorized_groups:
     - hris_is_staff
     - team_moco
     - team_mofo
@@ -2649,19 +2636,6 @@ apps:
     - hris_is_staff
     - team_moco
     - team_mofo
-    - statuspage_service_accounts
-    authorized_users: []
-    client_id: KqlGE124Mr21HFF3GwSlxEkOHlrX9EG6
-    display: false
-    logo: auth0.png
-    name: manage.statuspage.io
-    op: auth0
-    url: https://manage.statuspage.io/sso/saml/consume
-- application:
-    authorized_groups:
-    - hris_is_staff
-    - team_moco
-    - team_mofo
     - vpn_cloudops_shipit
     authorized_users: []
     client_id: 2dXygwTNP3p7iLTSaEWbdoiJFkjSBqm4
@@ -2764,19 +2738,6 @@ apps:
     name: https://anb1.fuzzing.mozilla.org/
     op: auth0
     url: https://anb1.fuzzing.mozilla.org/oidc/callback/
-- application:
-    authorized_groups:
-    - hris_is_staff
-    - team_moco
-    - team_mofo
-    - statuspage_service_accounts
-    authorized_users: []
-    client_id: qpmqtLlYhXKdezJK22j1zmML6cCLuvUg
-    display: false
-    logo: auth0.png
-    name: firefoxoperations.statuspage.io
-    op: auth0
-    url: https://manage.statuspage.io/sso/saml/consume
 - application:
     authorized_groups:
     - hris_is_staff
@@ -4141,3 +4102,49 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/rCUnlF5BH5z603b8eZ17Xb4SPnHaY4Zm
     vanity_url:
     - /new-relic-voice
+
+# StatusPage application, for general mofoco
+# TODO: Should this groups list match the other statuspage instances?
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: dc50KcxGnMPBOSlE5QLYaDRmfrO7oXhq
+    display: true
+    logo: statuspage.png
+    name: StatusPage
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/dc50KcxGnMPBOSlE5QLYaDRmfrO7oXhq
+    vanity_url:
+    - /statuspage
+# StatusPage site 'manage'
+# TODO: The URL below is 404. How do we access this? Is this still used?
+- application:
+    authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
+    - statuspage_service_accounts
+    authorized_users: []
+    client_id: KqlGE124Mr21HFF3GwSlxEkOHlrX9EG6
+    display: false
+    logo: auth0.png
+    name: manage.statuspage.io
+    op: auth0
+    url: https://manage.statuspage.io/sso/saml/consume
+# StatusPage site 'firefoxoperations'
+# TODO: The URL below is 404. How do we access this? Is this still used?
+- application:
+    authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
+    - statuspage_service_accounts
+    authorized_users: []
+    client_id: qpmqtLlYhXKdezJK22j1zmML6cCLuvUg
+    display: false
+    logo: auth0.png
+    name: firefoxoperations.statuspage.io
+    op: auth0
+    url: https://manage.statuspage.io/sso/saml/consume

--- a/apps.yml
+++ b/apps.yml
@@ -37,17 +37,6 @@ apps:
     - /netlify
 - application:
     authorized_groups:
-    - mozilliansorg_web-sre-aws-access
-    authorized_users: []
-    display: true
-    logo: newrelic.png
-    name: New Relic
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
-    vanity_url:
-    - /new-relic-sre
-- application:
-    authorized_groups:
     - team_moco
     - team_mofo
     authorized_users: []
@@ -3227,16 +3216,6 @@ apps:
     - /iam-graylog
 - application:
     authorized_groups:
-    - team_moco
-    authorized_users: []
-    client_id: tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
-    display: false
-    logo: auth0.png
-    name: New Relic IT SRE
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
-- application:
-    authorized_groups:
     - hris_is_staff
     - team_moco
     - team_mofo
@@ -3441,73 +3420,6 @@ apps:
     name: Cloudsnap
     op: auth0
     url: https://auth.mozilla.auth0.com/samlp/cuC3NOGPFm58H172NnOypPf1jGQwMoUf
-- application:
-    authorized_groups:
-    - hris_costcenter_1420
-    authorized_users: []
-    display: true
-    logo: newrelic.png
-    name: New Relic EIS
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/yrtYw37UYq5gkna3j9f0P4L0oQD8Y6aQ
-    vanity_url:
-    - /new-relic-eis
-- application:
-    authorized_groups:
-    - hris_is_staff
-    - team_moco
-    - team_mofo
-    authorized_users: []
-    client_id: Um2rLocE3s851JXNZzTPnA5DFzWe9OhQ
-    display: false
-    logo: newrelic.png
-    name: New Relic Emerging Tech
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/Um2rLocE3s851JXNZzTPnA5DFzWe9OhQ
-    vanity_url:
-    - /new-relic-emerging-tech
-- application:
-    authorized_groups:
-    - hris_is_staff
-    - team_moco
-    - team_mofo
-    authorized_users: []
-    client_id: VeOfYrHRjGuAauFAXRYv4z0rCFe4Ibbc
-    display: false
-    logo: newrelic.png
-    name: New Relic SubHub
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/VeOfYrHRjGuAauFAXRYv4z0rCFe4Ibbc
-    vanity_url:
-    - /new-relic-subhub
-- application:
-    authorized_groups:
-    - hris_is_staff
-    - team_moco
-    - team_mofo
-    authorized_users: []
-    client_id: dCRd3omR9fkejcm31qBw138SRJqg4M5i
-    display: false
-    logo: newrelic.png
-    name: New Relic Data
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/dCRd3omR9fkejcm31qBw138SRJqg4M5i
-    vanity_url:
-    - /new-relic-data
-- application:
-    authorized_groups:
-    - hris_is_staff
-    - team_moco
-    - team_mofo
-    authorized_users: []
-    client_id: rCUnlF5BH5z603b8eZ17Xb4SPnHaY4Zm
-    display: false
-    logo: newrelic.png
-    name: New Relic Voice
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/rCUnlF5BH5z603b8eZ17Xb4SPnHaY4Zm
-    vanity_url:
-    - /new-relic-voice
 - application:
     authorized_groups:
     - braintree_admin_sso
@@ -4131,3 +4043,101 @@ apps:
     name: Expensify (getpocket.com)
     op: auth0
     url: https://www.expensify.com/authentication/saml/loginCallback?domain=getpocket.com
+
+# New Relic accountid 2239138 "Mozilla SE"
+# Show the New Relic tile to members of the 'web-sre-aws-access' mozillians group.
+- application:
+    authorized_groups:
+    - mozilliansorg_web-sre-aws-access
+    authorized_users: []
+    display: true
+    logo: newrelic.png
+    name: New Relic
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
+    vanity_url:
+    - /new-relic-sre
+# Grant New Relic access to members of the 'team_moco' LDAP group.
+- application:
+    authorized_groups:
+    - team_moco
+    authorized_users: []
+    client_id: tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
+    display: false
+    logo: auth0.png
+    name: New Relic IT SRE
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
+# New Relic accountid 2235606 "Mozilla EIS"
+- application:
+    authorized_groups:
+    - hris_costcenter_1420
+    authorized_users: []
+    display: true
+    logo: newrelic.png
+    name: New Relic EIS
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/yrtYw37UYq5gkna3j9f0P4L0oQD8Y6aQ
+    vanity_url:
+    - /new-relic-eis
+# New Relic accountid 1807330 "Mozilla Emerging Tech"
+- application:
+    authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: Um2rLocE3s851JXNZzTPnA5DFzWe9OhQ
+    display: false
+    logo: newrelic.png
+    name: New Relic Emerging Tech
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/Um2rLocE3s851JXNZzTPnA5DFzWe9OhQ
+    vanity_url:
+    - /new-relic-emerging-tech
+# New Relic accountid 2423519 "Mozilla SubHub"
+- application:
+    authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: VeOfYrHRjGuAauFAXRYv4z0rCFe4Ibbc
+    display: false
+    logo: newrelic.png
+    name: New Relic SubHub
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/VeOfYrHRjGuAauFAXRYv4z0rCFe4Ibbc
+    vanity_url:
+    - /new-relic-subhub
+# New Relic accountid 2239137 "Mozilla Data"
+- application:
+    authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: dCRd3omR9fkejcm31qBw138SRJqg4M5i
+    display: false
+    logo: newrelic.png
+    name: New Relic Data
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/dCRd3omR9fkejcm31qBw138SRJqg4M5i
+    vanity_url:
+    - /new-relic-data
+# New Relic accountid unknown "unknown"
+# TODO: Investigate this entry and see if it's still necessary (SE-1459)
+- application:
+    authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
+    authorized_users: []
+    client_id: rCUnlF5BH5z603b8eZ17Xb4SPnHaY4Zm
+    display: false
+    logo: newrelic.png
+    name: New Relic Voice
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/rCUnlF5BH5z603b8eZ17Xb4SPnHaY4Zm
+    vanity_url:
+    - /new-relic-voice

--- a/apps.yml
+++ b/apps.yml
@@ -1377,20 +1377,6 @@ apps:
     - /syntrio
 - application:
     authorized_groups:
-    - team_moco
-    - team_mofo
-    - team_mozillaonline
-    authorized_users:
-    - billing@mozilla.com
-    display: true
-    logo: expensify.png
-    name: Expensify
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/adMlV8Ud0Z77GLfsaa4fb4oQj8ggf0ws
-    vanity_url:
-    - /expensify
-- application:
-    authorized_groups:
     - mozilliansorg_gcp-infrastructure-production
     - service_meao_gcp
     authorized_users: []
@@ -2700,19 +2686,6 @@ apps:
     - hris_is_staff
     - team_moco
     - team_mofo
-    authorized_users:
-    - billing@mozilla.com
-    client_id: 6BLpfXP845A8yris7DaPST25HycC7l2u
-    display: false
-    logo: auth0.png
-    name: Expensify (getpocket.com)
-    op: auth0
-    url: https://www.expensify.com/authentication/saml/loginCallback?domain=getpocket.com
-- application:
-    authorized_groups:
-    - hris_is_staff
-    - team_moco
-    - team_mofo
     authorized_users: []
     client_id: 5tkbwIFZqYLtZtFIDki6Nqpt8GHUzZ2J
     display: false
@@ -3118,19 +3091,6 @@ apps:
     name: DAM Stage (NetX)
     op: auth0
     url: https://mozillatest.netx.net/SSO
-- application:
-    authorized_groups:
-    - hris_is_staff
-    - team_moco
-    - team_mofo
-    authorized_users:
-    - billing@mozilla.com
-    client_id: adMlV8Ud0Z77GLfsaa4fb4oQj8ggf0ws
-    display: false
-    logo: auth0.png
-    name: Expensify
-    op: auth0
-    url: https://www.expensify.com/authentication/saml/loginCallback?domain=mozilla.com
 - application:
     authorized_groups:
     - hris_is_staff
@@ -4124,3 +4084,50 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/2igLHKcnjKFZDp5qOzONLM951lnJscOu
     vanity_url:
     - /talentwall
+
+# Expensify for everyone has no client_id, but the URL's client ID matches below.
+# TODO: client_id is not set; other instances of the client ID in the URL may affect access.
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    - team_mozillaonline
+    authorized_users:
+    - billing@mozilla.com
+    display: true
+    logo: expensify.png
+    name: Expensify
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/adMlV8Ud0Z77GLfsaa4fb4oQj8ggf0ws
+    vanity_url:
+    - /expensify
+# Expensify for 'mozilla.com' has a client_id, duplicating the URL's above.
+# TODO: Does MozillaOnline have appropriate access?
+- application:
+    authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
+    authorized_users:
+    - billing@mozilla.com
+    client_id: adMlV8Ud0Z77GLfsaa4fb4oQj8ggf0ws
+    display: false
+    logo: auth0.png
+    name: Expensify
+    op: auth0
+    url: https://www.expensify.com/authentication/saml/loginCallback?domain=mozilla.com
+# Expensify for getpocket.com has a different client ID than MoCo above.
+# TODO: Verify that this still functions and is needed.
+- application:
+    authorized_groups:
+    - hris_is_staff
+    - team_moco
+    - team_mofo
+    authorized_users:
+    - billing@mozilla.com
+    client_id: 6BLpfXP845A8yris7DaPST25HycC7l2u
+    display: false
+    logo: auth0.png
+    name: Expensify (getpocket.com)
+    op: auth0
+    url: https://www.expensify.com/authentication/saml/loginCallback?domain=getpocket.com


### PR DESCRIPTION
While working on SE-2440 we noticed that complicated SSO entries are spread out throughout the file. This PR attempts to improve that somewhat and includes comments from our analysis and intentions.

This should have zero functional changes to any service listed, and I did my best to retain the ordering in case that's secretly relevant.