### PR TITLE
Limit udemy/getabstract to MoCo staff, when MoCo [#1722338]

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3717,8 +3717,7 @@ apps:
     url: https://glam.telemetry.mozilla.org
 - application:
     authorized_groups:
-    - hris_is_staff
-    - team_moco
+    - team_moco_benefited
     - team_mofo
     - team_mozillaonline
     authorized_users: []
@@ -3732,8 +3731,7 @@ apps:
     - /udemy
 - application:
     authorized_groups:
-    - hris_is_staff
-    - team_moco
+    - team_moco_benefited
     - team_mofo
     - team_mozillaonline
     authorized_users: []
@@ -3745,8 +3743,7 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/w8hBBYB30b12DqElacIQkFM6V2deEpwz
 - application:
     authorized_groups:
-    - hris_is_staff
-    - team_moco
+    - team_moco_benefited
     - team_mofo
     - team_mozillaonline
     authorized_users: []


### PR DESCRIPTION
For staff that are MoCo, we intend these services to be limited to benefited staff. This requires the updated team_moco_benefited group as well as removal of the 'all' hris_is_staff group.