### PR TITLE
assign reviews to sso-dashboard-reviewers via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Assign all reviews to the SSO Dashboard Reviewers team, by default.
+#
+# This team must be assigned Role: Write (or better) in the repository
+# for GitHub to apply this default for new pull requests.
+# https://github.com/mozilla-iam/sso-dashboard-configuration/settings/access
+
+* @mozilla-iam/sso-dashboard-reviewers


### PR DESCRIPTION
I did my best to interpret the CODEOWNERS documentation from GitHub:

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax

When creating this file, but input welcome if anyone sees ways to improve it.