### PR TITLE
Internal Pocket Admin Tools [#1730268]

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -4088,3 +4088,13 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/hYQggi94XNgMBJCuENbUA1ec7uoRLecO
     vanity_url:
     - /fivetran
+- application:
+    authorized_groups:
+    - team_moco
+    authorized_users: []
+    client_id: qyHptHsoTtUJR9K4xDirWZUy30cqpeWT
+    display: false
+    logo: auth0.png
+    name: Internal Pocket Admin Tools
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/qyHptHsoTtUJR9K4xDirWZUy30cqpeWT


### PR DESCRIPTION
Confirmed via slack, `moco` is the only group that should have access.