### PR TITLE
add a PR template note about default reviewers

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+# All PRs are assigned reviewers by default; selecting your own is optional.


### PR DESCRIPTION
The GitHub UI can make it seem like selecting a reviewer is mandatory, but we've got that covered.