### PR TITLE
Looker people [IAM-912]

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -4108,7 +4108,7 @@ apps:
     - /sentry
 - application:
     authorized_groups:
-    - team_moco
+    - mozilliansorg_looker-people-access
     authorized_users: []
     client_id: h0xnB8lHw5Gfapsg0AA8XH8jZvT1FEBv
     display: true

--- a/apps.yml
+++ b/apps.yml
@@ -4106,3 +4106,15 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/94A5PWkgKK2sJKxUnF8O8k5rNtEMdngk
     vanity_url:
     - /sentry
+- application:
+    authorized_groups:
+    - team_moco
+    authorized_users: []
+    client_id: h0xnB8lHw5Gfapsg0AA8XH8jZvT1FEBv
+    display: true
+    logo: looker.png
+    name: Looker (People)
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/h0xnB8lHw5Gfapsg0AA8XH8jZvT1FEBv
+    vanity_url:
+    - /looker-people


### PR DESCRIPTION
This PR adds the looker (People) instance to the SSO dashboard.  This needs to be in place before completing the SAML configuration in the looker instance in order to prevent unauthorized access.
https://mozilla-hub.atlassian.net/browse/IAM-912