### PR TITLE
chore(statuspage): Update URL for Status Page

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -793,12 +793,11 @@ apps:
     - team_moco
     - team_mofo
     authorized_users: []
-    client_id: dc50KcxGnMPBOSlE5QLYaDRmfrO7oXhq
     display: true
     logo: statuspage.png
     name: StatusPage
     op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/dc50KcxGnMPBOSlE5QLYaDRmfrO7oXhq
+    url: https://manage.statuspage.io/cloud/d8febd08-c6e9-4c03-9c13-db37c2369ce5
     vanity_url:
     - /statuspage
 - application:


### PR DESCRIPTION
Authentication for Status Page was integrated directly into Atlassian hub. Since we use auth there we no longer need a separate login or application for status page. This points directly at the management page for our account.