### PR TITLE
temp disable mzla for live migrations

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -53,7 +53,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     display: true
     logo: accountmanager.png
@@ -90,7 +90,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: el46s4SPK4ZOhQBsAjtiDYKFQkXK76xm
     display: false
@@ -104,7 +104,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 9F55B8e5VmFl4lCgYObnA1TkyRFTxQ9M
     display: false
@@ -119,7 +119,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     - mozilliansorg_nda
     authorized_users: []
@@ -189,7 +189,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users:
     - casa-fivetran@mozilla.com
     client_id: IU80mVpKPtIZyUZtya9ZnSTs6fKLt3JO
@@ -271,7 +271,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 72Q4MlsbMzRo5Sij6y5JPDAiyGcyDKB2
     display: false
@@ -305,7 +305,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: ap9HoUbKeTrt33vA9MSayfCS2CWxiPcz
     display: true
@@ -319,7 +319,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users:
     - calendars@mozilla.com
     client_id: DhBV04HLs6H8OeTHOlodz0LtkyY7VTU0
@@ -346,7 +346,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillajapan
     - team_mozillaonline
     authorized_users: []
@@ -362,7 +362,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     authorized_users: []
     client_id: eaiAVdOLtf2KXZvexyCCViw0154E0U6x
@@ -377,7 +377,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillajapan
     - team_mozillaonline
     - gsuite_shared_accounts
@@ -397,7 +397,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillajapan
     - team_mozillaonline
     - gsuite_shared_accounts
@@ -415,7 +415,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillajapan
     - team_mozillaonline
     - gsuite_shared_accounts
@@ -433,7 +433,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: TGlmvMW4kvEz99CRnuGnNTfxku0QNn8e
     display: true
@@ -479,7 +479,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - everyone
     authorized_users: []
     client_id: f4SlPDVeVcWBChrAvH8uLuEYyt0aW916
@@ -493,7 +493,7 @@ apps:
     - service_lucidchart
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 80JNexePA737rSLhBAABqIvMJTEAn11u
     display: false
@@ -521,7 +521,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - service_jira
     - moc_service_accounts
     - mozilliansorg_jira_vendors
@@ -536,7 +536,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     authorized_users: []
     client_id: TKqD0MP8sDeJAc9QC4f5yp2r9qbx5fcZ
@@ -551,7 +551,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     authorized_users: []
     client_id: 8IhkiQO1reUO0an6e95CJ6EMBg7Lg5xQ
@@ -655,7 +655,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 4HNLHcA7ZSNVWSJVBk9yVxq06WRquN2L
     display: false
@@ -669,7 +669,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - everyone
     authorized_users: []
     client_id: Gav1XmmrpBxts0zeDPOSfGesVrTt044k
@@ -694,7 +694,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: DBRlLjVEUbw1yWrUYAHNYl22KBkKAjql
     display: true
@@ -720,7 +720,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 3rbiX5U5EZZFf9tvYpOdoUxJ6A2TnH2q
     display: true
@@ -744,7 +744,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - everyone
     authorized_users: []
     client_id: ByW5ChOPpsQaQFLcAuZBbtjFrh67uBgt
@@ -758,7 +758,7 @@ apps:
 - application:
     authorized_groups:
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: Vnj9iPj1FJz4xTlco6XHLwM3oyRUO9iQ
     display: true
@@ -772,7 +772,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - everyone
     authorized_users: []
     client_id: 54KBW3ESzKFfQws77PCXziJnPt0dYHE0
@@ -827,7 +827,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     display: true
     logo: statuspage.png
@@ -840,7 +840,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - everyone
     authorized_users: []
     client_id: Wz5oO6y8oJ35Yq1B91aC4pkwlXdes7jR
@@ -863,7 +863,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - tableau_users
     - moc_service_accounts
     authorized_users: []
@@ -879,7 +879,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - tableau_users
     - moc_service_accounts
     authorized_users: []
@@ -906,7 +906,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillajapan
     - team_mozillaonline
     - moc_service_accounts
@@ -939,7 +939,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: Hypn042D0cqtqET33nRrnqOwAcIXOqx6
     display: true
@@ -953,7 +953,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - everyone
     authorized_users: []
     client_id: kyeMyPALPK84A58vlOnb7lrCzAIFJapP
@@ -966,7 +966,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - everyone
     authorized_users: []
     client_id: pRwf1AWvIO5t4zyMsF8R18wtt1jfLp5o
@@ -980,7 +980,7 @@ apps:
     - mozilliansorg_slack-access
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     authorized_users: []
     client_id: WXVdgVoCca11OtpGlK8Ir3pR9CBAlSA5
@@ -1008,7 +1008,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: meBoR5vlD0kK0qeUXshNjOB1PbGKjsro
     display: false
@@ -1022,7 +1022,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: j8FN0DB6RwrlfLhX4opVAZ2tDYbBiMMU
     display: false
@@ -1036,7 +1036,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - everyone
     authorized_users: []
     client_id: i55sTCbmgUTkvHPW3SDueKlKbtPj5iRF
@@ -1065,7 +1065,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - cloudops_atmo_access
     authorized_users: []
     client_id: 6GDrRrIYZuRRKLXXbucm4bO0eafK0AKN
@@ -1145,7 +1145,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - everyone
     authorized_users: []
     client_id: VjJFa4EeFWd29pMnhyAk7AkGW2ids5UX
@@ -1160,7 +1160,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: t1KWNQt71oskeip2KCu9j0KhwJJbBkig
     display: false
@@ -1172,7 +1172,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: uMkOuQX8LGTxAyYIiX4eLoc4hl0pWSJt
     display: false
@@ -1197,7 +1197,7 @@ apps:
     - mozilliansorg_nda
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users:
     - mozboxadmin@mozilla.com
     - servicedesk@mozilla.com
@@ -1225,7 +1225,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: ChKEapjEYTPx0T1b5QP01WhAeP8ymRJ7
     display: false
@@ -1237,7 +1237,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     authorized_users:
     - billing@mozilla.com
@@ -1282,7 +1282,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     - zoom_non_staff
     - mozilliansorg_community-zoom
@@ -1355,7 +1355,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: tU9fTz20E17hlFVo2DViKtDLABzVxrir
     display: true
@@ -1369,7 +1369,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 64Ud5s4qJ3GgFZQ2rUG2D4Fod0lYoUu0
     display: true
@@ -1383,7 +1383,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     authorized_users: []
     client_id: iz2qSHo0lSv2nRZ8V3JnOESX5UR4dcpX
@@ -1486,7 +1486,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: mC9OzwCHicAsokpRyJt468BTlO8bl5C4
     display: false
@@ -1620,7 +1620,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - mozilliansorg_nda
     - mozilliansorg_dinopark-dev
     authorized_users: []
@@ -1770,7 +1770,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: P5kUBn21KQ5m8IRMdNFONg17dJ9qTrlP
     display: false
@@ -1782,7 +1782,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - mozilliansorg_nda
     authorized_users: []
     client_id: AJBSCa58Vu3bi1OiL30s2yCTXUkBj6KR
@@ -1797,7 +1797,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: DGloMN2BXb0AC7lF5eRyOe1GXweqBAiI
     display: false
@@ -1820,7 +1820,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: zk9N7LU2ihMIy0bwlGd7GfRVXDKsGQjI
     display: false
@@ -1844,7 +1844,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 31dwqlImDXaTqW7m8E0YY5CN16ZLf72Q
     display: false
@@ -1858,7 +1858,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     authorized_users: []
     client_id: 2dbkrvUJa5gnxGSnMLZ1jflbtrahhrEi
@@ -1873,7 +1873,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: WuFEV87Q4or1WlncXR3WRgcbD1oceeme
     display: false
@@ -1885,7 +1885,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: Lh20PL4WfuZRoZ45dCW0PbnTN8wqN8fd
     display: false
@@ -1897,7 +1897,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - mozilliansorg_non-moco-sheriffs-basic
     authorized_users: []
     client_id: jGx4Z2JTWsgQWiBmvrCNbe5WXAfMivzb
@@ -1910,7 +1910,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: WLQrmFTcXlSDelnxOASZ4KJQTE5gXZFt
     display: false
@@ -1922,7 +1922,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: dWcDz6ZYNuevquzzvAgRYOgBZLxY0ucx
     display: false
@@ -1934,7 +1934,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: k3JF93rR1HI7O2HEndhCI0p1ZyBhhMCr
     display: false
@@ -1946,7 +1946,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     authorized_users: []
     client_id: OlwWsXslbA9wk5lQOHUDIUSrtIFTauTy
@@ -1959,7 +1959,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: m6x0phAu4rq4imC6f6gRYaGmQgStCdlG
     display: false
@@ -1971,7 +1971,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     authorized_users: []
     client_id: 7YTXsNQhLSiNsXPtDdXdvryD5dN30DEb
@@ -1984,7 +1984,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: UR9C6jNpAxXBv0bEnzDsHGUQAEyasre2
     display: false
@@ -1996,7 +1996,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: wC5AsSzi8BbDHHDDieRjU3mcpEeTVcwj
     display: false
@@ -2008,7 +2008,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: dVL10G8KVJymQ6Tx6naRZRbX6L8rhO1E
     display: false
@@ -2020,7 +2020,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 7jfouvibRlddw49I8prbSl2xrxKXwwoh
     display: false
@@ -2032,7 +2032,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: R04ouRZsRnbVXztgFEA0ZdNUia6WMFa1
     display: false
@@ -2044,7 +2044,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 8udOeshOuK7LREPL0G5Z9n2mY4expDLx
     display: false
@@ -2056,7 +2056,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 33XOsgKlENOSLXLtRv7Vb65v38plFwlg
     display: false
@@ -2068,7 +2068,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: l7kCqo8U1Ka2ZtlE85Dmy2a8Ic1I8y7H
     display: false
@@ -2080,7 +2080,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: EtCJe9m2NFGF4TO0kIfPoT7gQqTKU0DE
     display: false
@@ -2092,7 +2092,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: MmT719PU6y84GsRkym00nVvVHi2y5hPa
     display: false
@@ -2104,7 +2104,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: Hi9rqHLPlnpRfMkc7dtkToFc3DHtcf4Z
     display: false
@@ -2116,7 +2116,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: hIjZmDmmtkKuaOjmhd5HUzn0ResPDeqX
     display: false
@@ -2128,7 +2128,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 1QcjRY2UEYySI79IqorH94Td590oqXSA
     display: false
@@ -2140,7 +2140,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - vpn_cloudops_shipit
     authorized_users: []
     client_id: 4u5EiGAICaWFmsyWamVaN1D4f4P6MlR0
@@ -2153,7 +2153,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: XwWBobhe6XlQrngdct8sEdLFAgsW89yB
     display: false
@@ -2165,7 +2165,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - mozilliansorg_nda
     authorized_users: []
     client_id: 462AVvm5b1GOLD0z7Gao0Eje24aF3Kz0
@@ -2178,7 +2178,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: xTQ9ithTGuqzB0MaPkafbj3Q6HTE2vM0
     display: false
@@ -2190,7 +2190,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: bSCGkqkGbQPAuIDt0kYqmnhimlkh2kwH
     display: false
@@ -2202,7 +2202,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: m772guBT5bEt60OCg4l11NbwDbOX2SLm
     display: false
@@ -2214,7 +2214,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - mozilliansorg_project-link-aws-admin
     - mozilliansorg_searchfox-aws  # https://bugzilla.mozilla.org/show_bug.cgi?id=1677158
     authorized_users: []
@@ -2228,7 +2228,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: hGFkZoxf7dzKy3PIsT7w2XTBQOhb3ZK0
     display: false
@@ -2240,7 +2240,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: IVq10RLJgYIQX9Mzzr0hPhDkyix6kZQb
     display: false
@@ -2252,7 +2252,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: W3SoWmYcqvP2Yms14s5VTeUFCZmBOJPT
     display: false
@@ -2264,7 +2264,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: Zs6FFIXPUstFKpzBau4cRQ1aFBx4dKBR
     display: false
@@ -2276,7 +2276,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: iQwPHkpTw1RmbYe6ov2qFMfxbVN7DOB7
     display: false
@@ -2288,7 +2288,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: L0Eq6oW30PeB6mYt8NlsaZ2WqC9sj40n
     display: false
@@ -2300,7 +2300,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: albdy7m1X0YqdKEYx6qiJ9dKfg4ousn0
     display: false
@@ -2312,7 +2312,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: N3GRGrtTfNehZYvC3vWVUgd7Rk9F2Opb
     display: false
@@ -2324,7 +2324,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - mozilliansorg_nda
     authorized_users: []
     client_id: 725CWQLZ1oOt8XEnjsMvjYkZMZna2Y1V
@@ -2337,7 +2337,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 0igrKwGTBpqNHUhPMikxMwjOrZfmzaRh
     display: false
@@ -2349,7 +2349,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 29t2n3LKKnyTbGtWmfTkQpau0mp7QmMH
     display: false
@@ -2361,7 +2361,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: n0L5J2H8fk5T4G7Ma4Ke75Hc6Be5hsRV
     display: false
@@ -2373,7 +2373,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 3a6sbM3CfbTQ8YkZ4wW7YpOdNN5NX4Hb
     display: false
@@ -2385,7 +2385,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 47BCiKGMwpCH5K7IzmJ1DjrHSo82krNs
     display: false
@@ -2397,7 +2397,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: XMAlQpd3P8y34lZF2EvgdNkNxWIP3KD2
     display: false
@@ -2409,7 +2409,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: VEVkmAppSLa3zc9VRhjkDJPwNSs6Zy7B
     display: false
@@ -2424,7 +2424,7 @@ apps:
     - stmo_nda
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: rgE6x7G6X1i3TjOy43qYG8vbcyKtcN6E
     display: false
@@ -2436,7 +2436,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: LNPKbJGoCqEBuCtIZIoJg08V4QtNzfYJ
     display: false
@@ -2448,7 +2448,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: a8153qZo1lnReZ3hj3ZCmP8YMzArrHqU
     display: false
@@ -2460,7 +2460,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 1KN7o6GO88DyTLHW5WlsMm5V3qNRv7Ac
     display: false
@@ -2472,7 +2472,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: nIqcS6cAGY2WRA5466YngH44T4xrrvCt
     display: false
@@ -2484,7 +2484,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - mozilliansorg_shipit_devs
     authorized_users: []
     client_id: FK1mJkHhwjulTYBGklxn8W4Fhd1pgT4t
@@ -2497,7 +2497,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: btcSD131nsA7Mv1g01U535XPRG3qdNFp
     display: false
@@ -2509,7 +2509,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - statuspage_service_accounts
     authorized_users: []
     client_id: KqlGE124Mr21HFF3GwSlxEkOHlrX9EG6
@@ -2522,7 +2522,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - vpn_cloudops_shipit
     authorized_users: []
     client_id: 2dXygwTNP3p7iLTSaEWbdoiJFkjSBqm4
@@ -2535,7 +2535,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users:
     - billing@mozilla.com
     client_id: 6BLpfXP845A8yris7DaPST25HycC7l2u
@@ -2548,7 +2548,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 5tkbwIFZqYLtZtFIDki6Nqpt8GHUzZ2J
     display: false
@@ -2570,7 +2570,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: M4TY5gZQ6nUyMIjWpXWFffRJ9pD3qPb2
     display: false
@@ -2582,7 +2582,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: d8fRO14gY7fhl54HU1yDemdJxJMTIV5Q
     display: false
@@ -2594,7 +2594,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: rrXGZ6x7J4MIWWlQ6zhTzgED2GxIsHCv
     display: false
@@ -2606,7 +2606,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: s7ICwWzGSP8WRnAkAMpIjDyayaEIOneU
     display: false
@@ -2618,7 +2618,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: AmqnIoKbdd59LaI4wt0pOPkuUHeMchJf
     display: false
@@ -2630,7 +2630,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 6BFjR5hArHbV7dzyUy2VYmnXCV5B0pdo
     display: false
@@ -2642,7 +2642,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - statuspage_service_accounts
     authorized_users: []
     client_id: qpmqtLlYhXKdezJK22j1zmML6cCLuvUg
@@ -2655,7 +2655,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: amWBDrIIzlk2pyjgCyLruw0n9wplzUlm
     display: false
@@ -2667,7 +2667,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: Ef6czTFBKvTUR3FW08tYobaMGEnk9bzB
     display: false
@@ -2679,7 +2679,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: ov4iTFaVzWnvGme0x7FmRarIvu10I08M
     display: false
@@ -2691,7 +2691,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: rvidaekCvn75vjMcDiBGz2lsmQLDuoou
     display: false
@@ -2703,7 +2703,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: xZWh7NZy5TB6IZ7hFPTIfL0Q0XqAW7st
     display: false
@@ -2715,7 +2715,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 5Z2yOkD1vAU6wAKX3mkFEwBWK8kBBpJD
     display: false
@@ -2727,7 +2727,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: K3ZolIlVbVH41tI9czWdQaPAHWriGx92
     display: false
@@ -2739,7 +2739,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: F1VVD6nRTckSVrviMRaOdLBWIk1AvHYo
     display: false
@@ -2751,7 +2751,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: dXTkbChUpSCKkj3YpY4KxpZ0iYg0tkNy
     display: false
@@ -2763,7 +2763,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: saSz4srpJGtdSMS62v47Xb2FOQtT2xBF
     display: false
@@ -2775,7 +2775,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: hU1YpGcL82wL04vTPsaPAQmkilrSE7wr
     display: false
@@ -2787,7 +2787,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: teqIfOHtaidNWTa79bt7VJwf2Trr3ALQ
     display: false
@@ -2799,7 +2799,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: e1g4q4s7Q2Jos5XOt6pyHVA9JH4G3xjJ
     display: false
@@ -2811,7 +2811,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: zw5M6MyDDixeSXQR2XiDZz46hSOKIHhr
     display: false
@@ -2823,7 +2823,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: q0tFB9QyFIKqPOOKvkFnHMj2VwrLjX46
     display: false
@@ -2835,7 +2835,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: vgDriXO3k0LThShbbJUfgl23uAT2MKBp
     display: false
@@ -2847,7 +2847,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: m35Bq2g6bRV37rs3cGa4UBR0qNI3IBKR
     display: false
@@ -2859,7 +2859,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users:
     - iris-testing@mozilla.com
     client_id: 383wZyKOqULjvIJnA4Njz04lztkmxKjf
@@ -2872,7 +2872,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: TTPiEfB9nU0DxzvFxCrj2HYmCtLP1NR3
     display: false
@@ -2884,7 +2884,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - mozilliansorg_nda
     authorized_users: []
     client_id: y2cZ14lTdsMjJdjmUNQ3PaLDrBCNJUZl
@@ -2897,7 +2897,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: BDRmLMBwmCqyBsL52IuQW8wLBLoLSBWo
     display: false
@@ -2909,7 +2909,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: LdGd1MOIwHD7flZjj5OuQlzGVAyakGvj
     display: false
@@ -2921,7 +2921,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - mozilliansorg_nda
     authorized_users: []
     client_id: a9d4XdRa07eZxC6GoPUI6WDFjvfyE9sY
@@ -2934,7 +2934,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: wP33JOFmHQEd2TOHftxIppprqCnJzo3m
     display: false
@@ -2946,7 +2946,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users:
     - billing@mozilla.com
     client_id: adMlV8Ud0Z77GLfsaa4fb4oQj8ggf0ws
@@ -2959,7 +2959,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: Scha3pS5Y3vITvnhnbLxSla2MBMPdo3M
     display: false
@@ -2971,7 +2971,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: fkfhxgxU868c6OSstYP4FwPzGzM534r5
     display: false
@@ -2983,7 +2983,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: Ury9HCvBS4B1SzAH8f3YASbbcGf5QlQf
     display: false
@@ -2995,7 +2995,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: sAwFfYrOicxvNjkA75pdZUvkPcJqUPl3
     display: false
@@ -3007,7 +3007,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: wwJwws9XZ6AVA48QOUU2FCGa6XP4U3aQ
     display: false
@@ -3021,7 +3021,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: SJmdyaeuz4SkdoWgOXZxVFeQukpt5SMo
     display: false
@@ -3033,7 +3033,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: pKXyeYwf5sIG6vImQ0HLvPpfzbZObhX0
     display: false
@@ -3056,7 +3056,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - mozilliansorg_nda
     authorized_users: []
     client_id: JW5noOxn5yRl3HbThBAqet7yLqu5uoTm
@@ -3069,7 +3069,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: nJkH6xvVNwogpLjkrTePAKwjB4NpE74h
     display: false
@@ -3103,7 +3103,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: pTTMCxf9YNo4zPOE2l81JqIGHbxkotuJ
     display: false
@@ -3115,7 +3115,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: HhsEpi14LlupTdZJjWcbsfWU0w8dVPxT
     display: false
@@ -3127,7 +3127,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: Vq6X0h7r43esUhNmrbUD1HBZskVejhHW
     display: false
@@ -3139,7 +3139,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     authorized_users: []
     client_id: m3UJJU40O2T6awdbhoA8V6onp3AbzU3Q
@@ -3168,7 +3168,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: uqaHX7JDz335eg0A89725t4GH5dLCUoW
     display: false
@@ -3180,7 +3180,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: NKhaOVehPM0VNljIiENTEP8jvaEUjYV3
     display: false
@@ -3192,7 +3192,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users:
     - dlipski@mozilla.com
     - jeide@mozilla.com
@@ -3322,7 +3322,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: Um2rLocE3s851JXNZzTPnA5DFzWe9OhQ
     display: false
@@ -3336,7 +3336,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: VeOfYrHRjGuAauFAXRYv4z0rCFe4Ibbc
     display: false
@@ -3350,7 +3350,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: rCUnlF5BH5z603b8eZ17Xb4SPnHaY4Zm
     display: false
@@ -3410,7 +3410,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: uGQC74llWoyAedpixUDpu8OLCf6GmqlC
     display: false
@@ -3436,7 +3436,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 7i1G4gM7zGuIE4h9T6s1Mho1e9P0cxk1
     display: false
@@ -3450,7 +3450,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: b2ESDyU2mJN5r6Ani52aIWxg0FoudEl8
     display: true
@@ -3465,7 +3465,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     authorized_users: []
     client_id: 7HxWt6W66K2QeytVVCeOoWpJxkVExnzz
@@ -3480,7 +3480,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: wgh8S9GaE7sJ4i0QrAzeMxFXgWZYtB0l
     display: false
@@ -3494,7 +3494,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: cEWzoPzUcDwk3JhpD9ENtPKMmE7T5QWv
     display: false
@@ -3506,7 +3506,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     authorized_users: []
     client_id: WlWmEUQ2dmQFQJfKxNx1ZNkAJRKueaR1
@@ -3519,7 +3519,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     authorized_users: []
     client_id: kfax6JBFqyXQcfEEQmEa56np04rm3uYX
@@ -3532,7 +3532,7 @@ apps:
     authorized_groups:
     - team_moco_benefited
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     - team_elance
     authorized_users: []
@@ -3548,7 +3548,7 @@ apps:
     authorized_groups:
     - team_moco_benefited
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     - team_elance
     authorized_users: []
@@ -3585,7 +3585,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: HNCCtcr6z8ZpFX3rT0K3SyDcNonByaUG
     display: false
@@ -3597,7 +3597,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: GYCcYQfcwVU9lwKF8WT4AvYufBvtp7yx
     display: false
@@ -3609,7 +3609,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: uSpi6gd7ZqdjA3PwtJ4CavG29DQJla4Y
     display: false
@@ -3649,7 +3649,7 @@ apps:
 - application:
     authorized_groups:
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 4b1qHRbxLmNLEBgXMi5eYP0sJn5p6q7l
     display: true
@@ -3663,7 +3663,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: HrdSoUsSJiJOKH2MICEXRXGMxTxUK5fa
     display: false
@@ -3675,7 +3675,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     authorized_users: []
     client_id: pozwk4HuT6AELY5Mf1oZPDdIDUo6VId4
@@ -3688,7 +3688,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: Nqo9YvvVxjpLDLPv7YGmpJXv2JNraUtH
     display: true
@@ -3700,7 +3700,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_pocket
     - team_mozillaonline
     authorized_users: []
@@ -3716,7 +3716,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: XCRyDou6ETr873QKnjaFgNsuiLKl6Oj2  # https://bugzilla.mozilla.org/show_bug.cgi?id=1681831
     display: false
@@ -3728,7 +3728,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: K1fsiDh5Ta7pc7BrEECi2VLhPyqHwy4r
     display: false
@@ -3740,7 +3740,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: wXpnkKIgoucVrybZmxiPnnpeSqn816qD
     display: false
@@ -3776,7 +3776,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     client_id: SS69h1GdOidHxtxeWLG2ryO5c6BYnj6O
     authorized_users: []
     display: true
@@ -3935,7 +3935,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 7M49iYODCiCGdldu4awmF2Pr6pHsRZDe
     display: false
@@ -3947,7 +3947,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 12lnezLro7iC57ooPPPpVeGHXf8MhaRV
     display: true
@@ -4010,7 +4010,7 @@ apps:
     - team_mozillaonline
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: 94A5PWkgKK2sJKxUnF8O8k5rNtEMdngk
     display: true
@@ -4095,7 +4095,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     - team_mozillaonline
     authorized_users: []
     client_id: yw8rP8c7Qir1SHybR6xUg7lZixz8FbVy
@@ -4120,7 +4120,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     client_id: DC94aLBL6OGoFuBFKgnVYBHanFP6stmV
     display: true


### PR DESCRIPTION
We're going to suspend the access while we migrate users, so that they don't suddenly see a full dashboard of new SSO apps that we haven't tested or setup integrations for yet (such as GApps and Zoom). We'll undo this piecemeal later as testing permits.