### PR TITLE
Update phpldapadmin configurations [SE-3246]

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -704,6 +704,16 @@ apps:
     logo: auth0.png
     name: PHPLDAPAdmin
     op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/W3SoWmYcqvP2Yms14s5VTeUFCZmBOJPT?RelayState=https://ldapmanager1.private.mdc1.mozilla.com/phpldapadmin/
+- application:
+    authorized_groups:
+    - ldapAdmins
+    authorized_users: []
+    client_id: W3SoWmYcqvP2Yms14s5VTeUFCZmBOJPT
+    display: true
+    logo: auth0.png
+    name: PHPLDAPAdmin
+    op: auth0
     url: https://auth.mozilla.auth0.com/samlp/W3SoWmYcqvP2Yms14s5VTeUFCZmBOJPT?RelayState=https://ldapadmin1.private.mdc1.mozilla.com/phpldapadmin/
 - application:
     authorized_groups:

--- a/apps.yml
+++ b/apps.yml
@@ -2269,18 +2269,6 @@ apps:
     - team_mofo
 #    - team_mzla
     authorized_users: []
-    client_id: W3SoWmYcqvP2Yms14s5VTeUFCZmBOJPT
-    display: false
-    logo: auth0.png
-    name: ldapadmin1.private.mdc1.mozilla.com/phpldapadmin
-    op: auth0
-    url: https://ldapadmin1.private.mdc1.mozilla.com/mellon/postResponse
-- application:
-    authorized_groups:
-    - team_moco
-    - team_mofo
-#    - team_mzla
-    authorized_users: []
     client_id: Zs6FFIXPUstFKpzBau4cRQ1aFBx4dKBR
     display: false
     logo: auth0.png


### PR DESCRIPTION
This is a 2-piece PR:
Commit 1 removes a superfluous definition of ldapadmin1's phpldapadmin configuration that shouldn't have been in place.  This was discovered in the process of researching this work.

Commit 2 makes a clone of the real phpldapadmin configuration, aiming it at a new server.  Once service work is completed, the old instance will be removed.