### PR TITLE
Cleanup of phpldapadmin entry [SE-3246]

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -707,7 +707,7 @@ apps:
     logo: auth0.png
     name: PHPLDAPAdmin
     op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/W3SoWmYcqvP2Yms14s5VTeUFCZmBOJPT?RelayState=https://ldapmanager1.private.mdc1.mozilla.com/phpldapadmin/
+    url: https://ldapmanager1.private.mdc1.mozilla.com/phpldapadmin/
 - application:
     authorized_groups:
     - team_moco

--- a/apps.yml
+++ b/apps.yml
@@ -710,16 +710,6 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/W3SoWmYcqvP2Yms14s5VTeUFCZmBOJPT?RelayState=https://ldapmanager1.private.mdc1.mozilla.com/phpldapadmin/
 - application:
     authorized_groups:
-    - ldapAdmins
-    authorized_users: []
-    client_id: W3SoWmYcqvP2Yms14s5VTeUFCZmBOJPT
-    display: true
-    logo: auth0.png
-    name: PHPLDAPAdmin
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/W3SoWmYcqvP2Yms14s5VTeUFCZmBOJPT?RelayState=https://ldapadmin1.private.mdc1.mozilla.com/phpldapadmin/
-- application:
-    authorized_groups:
     - team_moco
     - team_mofo
 #    - team_mzla


### PR DESCRIPTION
Dupe of #612, but with signed commits, sorry.

This is a followup to #611 .
Commit 1 removes the dupe created in that PR; Commit 2 changes our URL to the host instead of the long ugly SAML URL, as I have pivoted from SAML to OIDC on ldapmanager1.