### PR TITLE
Enable /accountmanager (login.m.c) for team_mzla

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -53,7 +53,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-#    - team_mzla
+    - team_mzla
     authorized_users: []
     display: true
     logo: accountmanager.png

--- a/apps.yml
+++ b/apps.yml
@@ -53,7 +53,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
+#    - team_mzla
     authorized_users: []
     display: true
     logo: accountmanager.png


### PR DESCRIPTION
Thunderbird folks already have login.m.c. access, this just enables the tile for them.

