### PR TITLE
add cbrentano@mozilla so I can test SSO for this app

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -1015,7 +1015,8 @@ apps:
     - team_pocket
     - travelling_accounts
     - mozilliansorg_slack_pocket_access
-    authorized_users: []
+    authorized_users:
+    - cbrentano@mozilla.com
     client_id: sZlNsFIG9f3vKrq9649Y7UxIyrmr8L7v
     display: true
     logo: slack.png


### PR DESCRIPTION
When doing a final check for enabling SSO on Pocket's Slack instance I realized that I would be locked out since I'm not a member of the authorized_groups, so this is just a temporary bodge to provide my LDAP user access so I can test things, afterwards I will revert this.
