### PR TITLE
Add team_gmail_only to access gmail

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -384,6 +384,7 @@ apps:
     - team_office_support
     - gsuite_shared_accounts
     - moc_service_accounts
+    - team_gmail_only
     authorized_users:
     - moc+servicenow@mozilla.com
     - moc-sso-monitoring@mozilla.com


### PR DESCRIPTION
Per an odd request, we'd like to have a group of users who
* aren't team_moco / other autogroup members,
* can access gmail
* can't access gcal/gdocs.

... and here we are.