### PR TITLE
Redo: Group certain complicated SSO entries together [SE-2440]

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -1208,22 +1208,6 @@ apps:
     url: https://admin.readitlater.com
 - application:
     authorized_groups:
-    - team_moco
-    - team_mofo
-#    - team_mzla
-    - team_mozillaonline
-    authorized_users:
-    - billing@mozilla.com
-    client_id: adMlV8Ud0Z77GLfsaa4fb4oQj8ggf0ws
-    display: true
-    logo: expensify.png
-    name: Expensify
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/adMlV8Ud0Z77GLfsaa4fb4oQj8ggf0ws
-    vanity_url:
-    - /expensify
-- application:
-    authorized_groups:
     - mozilliansorg_gcp-infrastructure-production
     - service_meao_gcp
     authorized_users: []
@@ -2475,19 +2459,6 @@ apps:
     - team_moco
     - team_mofo
 #    - team_mzla
-    authorized_users:
-    - billing@mozilla.com
-    client_id: 6BLpfXP845A8yris7DaPST25HycC7l2u
-    display: false
-    logo: auth0.png
-    name: Expensify (getpocket.com)
-    op: auth0
-    url: https://www.expensify.com/authentication/saml/loginCallback?domain=getpocket.com
-- application:
-    authorized_groups:
-    - team_moco
-    - team_mofo
-#    - team_mzla
     authorized_users: []
     client_id: 5tkbwIFZqYLtZtFIDki6Nqpt8GHUzZ2J
     display: false
@@ -2868,19 +2839,6 @@ apps:
     name: DAM Stage (NetX)
     op: auth0
     url: https://mozillatest.netx.net/SSO
-- application:
-    authorized_groups:
-    - team_moco
-    - team_mofo
-#    - team_mzla
-    authorized_users:
-    - billing@mozilla.com
-    client_id: adMlV8Ud0Z77GLfsaa4fb4oQj8ggf0ws
-    display: false
-    logo: auth0.png
-    name: Expensify
-    op: auth0
-    url: https://www.expensify.com/authentication/saml/loginCallback?domain=mozilla.com
 - application:
     authorized_groups:
     - team_moco
@@ -4194,3 +4152,45 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/rCUnlF5BH5z603b8eZ17Xb4SPnHaY4Zm
     vanity_url:
     - /new-relic-voice
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+#    - team_mzla
+    - team_mozillaonline
+    authorized_users:
+    - billing@mozilla.com
+    client_id: adMlV8Ud0Z77GLfsaa4fb4oQj8ggf0ws
+    display: true
+    logo: expensify.png
+    name: Expensify
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/adMlV8Ud0Z77GLfsaa4fb4oQj8ggf0ws
+    vanity_url:
+    - /expensify
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+#    - team_mzla
+    authorized_users:
+    - billing@mozilla.com
+    client_id: 6BLpfXP845A8yris7DaPST25HycC7l2u
+    display: false
+    logo: auth0.png
+    name: Expensify (getpocket.com)
+    op: auth0
+    url: https://www.expensify.com/authentication/saml/loginCallback?domain=getpocket.com
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+#    - team_mzla
+    authorized_users:
+    - billing@mozilla.com
+    client_id: adMlV8Ud0Z77GLfsaa4fb4oQj8ggf0ws
+    display: false
+    logo: auth0.png
+    name: Expensify
+    op: auth0
+    url: https://www.expensify.com/authentication/saml/loginCallback?domain=mozilla.com

--- a/apps.yml
+++ b/apps.yml
@@ -40,18 +40,6 @@ apps:
     - /netlify
 - application:
     authorized_groups:
-    - mozilliansorg_web-sre-aws-access
-    authorized_users: []
-    client_id: tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
-    display: true
-    logo: newrelic.png
-    name: New Relic
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
-    vanity_url:
-    - /new-relic-sre
-- application:
-    authorized_groups:
     - team_moco
     - team_mofo
     - team_mzla
@@ -3018,16 +3006,6 @@ apps:
 - application:
     authorized_groups:
     - team_moco
-    authorized_users: []
-    client_id: tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
-    display: false
-    logo: auth0.png
-    name: New Relic IT SRE
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
-- application:
-    authorized_groups:
-    - team_moco
     - team_mofo
 #    - team_mzla
     authorized_users: []
@@ -3189,60 +3167,6 @@ apps:
     name: FirefoxCI TaskCluster
     op: auth0
     url: https://firefox-ci-tc.services.mozilla.com/
-- application:
-    authorized_groups:
-    - hris_costcenter_1420
-    authorized_users: []
-    client_id: yrtYw37UYq5gkna3j9f0P4L0oQD8Y6aQ
-    display: true
-    logo: newrelic.png
-    name: New Relic EIS
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/yrtYw37UYq5gkna3j9f0P4L0oQD8Y6aQ
-    vanity_url:
-    - /new-relic-eis
-- application:
-    authorized_groups:
-    - team_moco
-    - team_mofo
-#    - team_mzla
-    authorized_users: []
-    client_id: Um2rLocE3s851JXNZzTPnA5DFzWe9OhQ
-    display: false
-    logo: newrelic.png
-    name: New Relic Emerging Tech
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/Um2rLocE3s851JXNZzTPnA5DFzWe9OhQ
-    vanity_url:
-    - /new-relic-emerging-tech
-- application:
-    authorized_groups:
-    - team_moco
-    - team_mofo
-#    - team_mzla
-    authorized_users: []
-    client_id: VeOfYrHRjGuAauFAXRYv4z0rCFe4Ibbc
-    display: false
-    logo: newrelic.png
-    name: New Relic SubHub
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/VeOfYrHRjGuAauFAXRYv4z0rCFe4Ibbc
-    vanity_url:
-    - /new-relic-subhub
-- application:
-    authorized_groups:
-    - team_moco
-    - team_mofo
-#    - team_mzla
-    authorized_users: []
-    client_id: rCUnlF5BH5z603b8eZ17Xb4SPnHaY4Zm
-    display: false
-    logo: newrelic.png
-    name: New Relic Voice
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/rCUnlF5BH5z603b8eZ17Xb4SPnHaY4Zm
-    vanity_url:
-    - /new-relic-voice
 - application:
     authorized_groups:
     - braintree_admin_sso
@@ -4194,3 +4118,79 @@ apps:
     name: firefoxoperations.statuspage.io
     op: auth0
     url: https://manage.statuspage.io/sso/saml/consume
+- application:
+    authorized_groups:
+    - mozilliansorg_web-sre-aws-access
+    authorized_users: []
+    client_id: tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
+    display: true
+    logo: newrelic.png
+    name: New Relic
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
+    vanity_url:
+    - /new-relic-sre
+- application:
+    authorized_groups:
+    - team_moco
+    authorized_users: []
+    client_id: tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
+    display: false
+    logo: auth0.png
+    name: New Relic IT SRE
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
+- application:
+    authorized_groups:
+    - hris_costcenter_1420
+    authorized_users: []
+    client_id: yrtYw37UYq5gkna3j9f0P4L0oQD8Y6aQ
+    display: true
+    logo: newrelic.png
+    name: New Relic EIS
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/yrtYw37UYq5gkna3j9f0P4L0oQD8Y6aQ
+    vanity_url:
+    - /new-relic-eis
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+#    - team_mzla
+    authorized_users: []
+    client_id: Um2rLocE3s851JXNZzTPnA5DFzWe9OhQ
+    display: false
+    logo: newrelic.png
+    name: New Relic Emerging Tech
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/Um2rLocE3s851JXNZzTPnA5DFzWe9OhQ
+    vanity_url:
+    - /new-relic-emerging-tech
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+#    - team_mzla
+    authorized_users: []
+    client_id: VeOfYrHRjGuAauFAXRYv4z0rCFe4Ibbc
+    display: false
+    logo: newrelic.png
+    name: New Relic SubHub
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/VeOfYrHRjGuAauFAXRYv4z0rCFe4Ibbc
+    vanity_url:
+    - /new-relic-subhub
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+#    - team_mzla
+    authorized_users: []
+    client_id: rCUnlF5BH5z603b8eZ17Xb4SPnHaY4Zm
+    display: false
+    logo: newrelic.png
+    name: New Relic Voice
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/rCUnlF5BH5z603b8eZ17Xb4SPnHaY4Zm
+    vanity_url:
+    - /new-relic-voice

--- a/apps.yml
+++ b/apps.yml
@@ -873,19 +873,6 @@ apps:
     - team_moco
     - team_mofo
 #    - team_mzla
-    authorized_users: []
-    display: true
-    logo: statuspage.png
-    name: StatusPage
-    op: auth0
-    url: https://manage.statuspage.io/cloud/d8febd08-c6e9-4c03-9c13-db37c2369ce5
-    vanity_url:
-    - /statuspage
-- application:
-    authorized_groups:
-    - team_moco
-    - team_mofo
-#    - team_mzla
     - everyone
     authorized_users: []
     client_id: Wz5oO6y8oJ35Yq1B91aC4pkwlXdes7jR
@@ -2487,19 +2474,6 @@ apps:
     - team_moco
     - team_mofo
 #    - team_mzla
-    - statuspage_service_accounts
-    authorized_users: []
-    client_id: KqlGE124Mr21HFF3GwSlxEkOHlrX9EG6
-    display: false
-    logo: auth0.png
-    name: manage.statuspage.io
-    op: auth0
-    url: https://manage.statuspage.io/sso/saml/consume
-- application:
-    authorized_groups:
-    - team_moco
-    - team_mofo
-#    - team_mzla
     - vpn_cloudops_shipit
     authorized_users: []
     client_id: 2dXygwTNP3p7iLTSaEWbdoiJFkjSBqm4
@@ -2603,19 +2577,6 @@ apps:
     name: https://anb1.fuzzing.mozilla.org/
     op: auth0
     url: https://anb1.fuzzing.mozilla.org/oidc/callback/
-- application:
-    authorized_groups:
-    - team_moco
-    - team_mofo
-#    - team_mzla
-    - statuspage_service_accounts
-    authorized_users: []
-    client_id: qpmqtLlYhXKdezJK22j1zmML6cCLuvUg
-    display: false
-    logo: auth0.png
-    name: firefoxoperations.statuspage.io
-    op: auth0
-    url: https://manage.statuspage.io/sso/saml/consume
 - application:
     authorized_groups:
     - team_moco
@@ -4194,3 +4155,42 @@ apps:
     url: https://3372492.app.netsuite.com/app/login/secure/oidc.nl
     vanity_url:
     - /netsuite
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+#    - team_mzla
+    authorized_users: []
+    display: true
+    logo: statuspage.png
+    name: StatusPage
+    op: auth0
+    url: https://manage.statuspage.io/cloud/d8febd08-c6e9-4c03-9c13-db37c2369ce5
+    vanity_url:
+    - /statuspage
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+#    - team_mzla
+    - statuspage_service_accounts
+    authorized_users: []
+    client_id: KqlGE124Mr21HFF3GwSlxEkOHlrX9EG6
+    display: false
+    logo: auth0.png
+    name: manage.statuspage.io
+    op: auth0
+    url: https://manage.statuspage.io/sso/saml/consume
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+#    - team_mzla
+    - statuspage_service_accounts
+    authorized_users: []
+    client_id: qpmqtLlYhXKdezJK22j1zmML6cCLuvUg
+    display: false
+    logo: auth0.png
+    name: firefoxoperations.statuspage.io
+    op: auth0
+    url: https://manage.statuspage.io/sso/saml/consume


### PR DESCRIPTION
A redo of https://github.com/mozilla-iam/sso-dashboard-configuration/pull/505 due to age/conflicts/etc.

> While working on SE-2440 we noticed that complicated SSO entries are spread out throughout the file. This PR attempts to improve that somewhat and includes comments from our analysis and intentions.
> 
> This should have zero functional changes to any service listed, and I did my best to retain the ordering in case that's secretly relevant.
