### PR TITLE
Redo: Standardize New Relic Access

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -4091,6 +4091,7 @@ apps:
 - application:
     authorized_groups:
     - team_moco
+    - team_mofo
     authorized_users: []
     client_id: tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
     display: false
@@ -4100,7 +4101,8 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
 - application:
     authorized_groups:
-    - hris_costcenter_1420
+    - team_moco
+    - team_mofo
     authorized_users: []
     client_id: yrtYw37UYq5gkna3j9f0P4L0oQD8Y6aQ
     display: true


### PR DESCRIPTION
Redoing due to age/conflicts/etc.

> Give everyone NR access. Do not display it for anyone, except I think for Web SRE who gets an override earlier in the file.
> 
> This was prompted by https://mozilla-hub.atlassian.net/browse/SE-1522
