### PR TITLE
Adds team_office_support to Box

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -1121,6 +1121,7 @@ apps:
     - mozilliansorg_boxcom-access
     - team_moco
     - team_mofo
+    - team_office_support
 #    - team_mzla
     authorized_users:
     - mozboxadmin@mozilla.com


### PR DESCRIPTION
So that sfomailroom can access the service, as well as other members of that group if they're added to the service later.