### PR TITLE
Make the Moderator tile visible

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -1322,7 +1322,7 @@ apps:
     - everyone
     authorized_users: []
     client_id: cav8o4za5QGMXilUEjglH9cgJpQl33Ck
-    display: false
+    display: true
     logo: auth0.png
     name: moderator.mozilla.org
     op: auth0


### PR DESCRIPTION
It was reported that the Moderator tile isn't visible on the dashboard. Sure enough, it's `display:` was set to `false`, this sets it to `true`.

I believe that this is a side-effect of the recent cleanup Van did which might have included a different Moderator tile which was visible, and somehow in all of that it got flipped false.