### PR TITLE
Update BitSight access control

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3368,8 +3368,8 @@ apps:
     - /everfi
 - application:
       authorized_groups:
-          - team_opsec
-          - team_secops
+          - mozilliansorg_bitsight-users
+          - mozilliansorg_bitsight-admins
       authorized_users: []
       client_id: eEAeYh6BMPfRyiSDax0tejjxkWi22zkP
       display: true


### PR DESCRIPTION
This changes the access control for BitSight so that it matches that access control used within the BitSight vendor. This way a user only need be added to, for example, the `bitsight-users` people.mozilla.org access group to get access to BitSight (instead of how it works currently where the user needs to be a member of both `bithsight-users` in people.mozilla.org and `team_opsec` in LDAP)
