### PR TITLE
Send slack notifications on deployments to google cloud storage

### DIFF
--- a/.github/workflows/google-deploy.yaml
+++ b/.github/workflows/google-deploy.yaml
@@ -9,6 +9,8 @@ on:
 
 env:
   BUCKET_NAME: sso-dashboard-${{ inputs.environment }}
+  CHANNEL_IDS: C05AMLCL4JX
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN}}
 
 jobs:
   deployment:
@@ -30,9 +32,44 @@ jobs:
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
           service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
 
+      - name: Send initial slack notification
+        uses: slackapi/slack-github-action@v1.24.0
+        id: slack
+        with:
+          channel-id: ${{ env.CHANNEL_IDS }}
+          payload-file-path: ".github/workflows/payload-slack-content.json"
+        env:
+          STATUS_COLOR: dbab09
+          STATUS_TITLE: "${{ env.BUCKET_NAME }} Deployment"
+          STATUS_VALUE: ':link-run: *Running*'
+
       - name: 'Upload to CDN bucket'
         id: 'upload-to-bucket'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
           path: './'
           destination: '${{ env.BUCKET_NAME }}'
+
+      - name: Update slack deployment complete
+        if: success()
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          update-ts: ${{ steps.slack.outputs.ts }}
+          channel-id: ${{ env.CHANNEL_IDS }}
+          payload-file-path: ".github/workflows/payload-slack-content.json"
+        env:
+          STATUS_COLOR: 28a745
+          STATUS_TITLE: "${{ env.BUCKET_NAME }} Deployment"
+          STATUS_VALUE: ':link-zelda: *Completed*'
+
+      - name: Update slack deployment failed
+        if: failure()
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          update-ts: ${{ steps.slack.outputs.ts }}
+          channel-id: ${{ env.CHANNEL_IDS }}
+          payload-file-path: ".github/workflows/payload-slack-content.json"
+        env:
+          STATUS_COLOR: d81313
+          STATUS_TITLE: "${{ env.BUCKET_NAME }} Deployment"
+          STATUS_VALUE: ':skull_and_crossbones: *Failed*'

--- a/.github/workflows/google-deploy.yaml
+++ b/.github/workflows/google-deploy.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   BUCKET_NAME: sso-dashboard-${{ inputs.environment }}
-  CHANNEL_IDS: C05AMLCL4JX
+  CHANNEL_IDS: C05AMLCL4JX #iam-notifications slack channel
   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN}}
 
 jobs:

--- a/.github/workflows/payload-slack-content.json
+++ b/.github/workflows/payload-slack-content.json
@@ -1,0 +1,63 @@
+{
+  "text": "",
+  "attachments": [
+    {
+      "color": "{{ env.STATUS_COLOR }}",
+      "blocks": [
+        {
+          "type": "header",
+          "text": {
+            "type": "plain_text",
+            "text": ":link-wut: Github Action Notification :link-wut:\n{{ github.workflow }}",
+            "emoji": true
+          }
+        },
+        {
+          "type": "section",
+          "fields": [
+            {
+              "type": "plain_text",
+              "text": "{{ env.RELEASE_NAME }}",
+              "emoji": true
+            },
+            {
+              "type": "plain_text",
+              "text": "{{ env.GITHUB_ACTOR }}",
+              "emoji": true
+            },
+            {
+              "type": "plain_text",
+              "text": "{{ env.GITHUB_REPOSITORY }}",
+              "emoji": true
+            },
+            {
+              "type": "plain_text",
+              "text": "{{ env.GITHUB_REF_NAME }}",
+              "emoji": true
+            }
+          ]
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "<https://github.com/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}|https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}>"
+          }
+        },
+        {
+          "type": "context",
+          "elements": [
+            {
+              "type": "mrkdwn",
+              "text": "Action: *{{ env.STATUS_TITLE }}*"
+            },
+            {
+              "type": "mrkdwn",
+              "text": "Status: {{ env.STATUS_VALUE }}"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR causes the github actions to send slack notifications when deploying to google cloud storage.