### PR TITLE
remove two decommissioned auth0 apps

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -1436,17 +1436,6 @@ apps:
     authorized_groups:
     - everyone
     authorized_users: []
-    client_id: 2KNOUCxN8AFnGGjDCGtqiDIzq8MKXi2h
-    display: false
-    logo: auth0.png
-    name: sso.allizom.org
-    op: auth0
-    url: http://localhost:5000/redirect_uri
-- application:
-    AAL: LOW
-    authorized_groups:
-    - everyone
-    authorized_users: []
     client_id: aJc4zjynRegTcrrxjB7PqV8lb9FdAVBr
     display: false
     logo: auth0.png
@@ -1581,17 +1570,6 @@ apps:
     name: Bugzilla Management Dashboard
     op: auth0
     url: https://bugzilla-management-dashboard.netlify.com/
-- application:
-    authorized_groups:
-    - team_services_ops
-    - balrog
-    authorized_users: []
-    client_id: BXaDyWq2F0MNWc56hTxVnM0SkMBXMG0d
-    display: true
-    logo: balrog.png
-    name: Balrog - previous
-    op: auth0
-    url: https://aus4-admin.mozilla.org
 - application:
     authorized_groups:
     - team_services_ops


### PR DESCRIPTION
While reviewing for another task, I noticed two apps that have invalid client_ids. I don't have context for their decom bugs, but here's a PR to remove them from apps.yml for the team to review and merge.