### PR TITLE
Add top-level text argument

### DIFF
--- a/.github/workflows/payload-slack-content.json
+++ b/.github/workflows/payload-slack-content.json
@@ -1,4 +1,5 @@
 {
+  "text": ":link-run:",
   "attachments": [
     {
       "color": "{{ env.STATUS_COLOR }}",


### PR DESCRIPTION
From last build:
```
Run slackapi/slack-github-action@v1.24.0
[WARN]  web-api:WebClient:0 The top-level `text` argument is missing in the request payload for a chat.postMessage call - It's a best practice to always provide a `text` argument when posting a message. The `text` is used in places where the content cannot be rendered such as: system push notifications, assistive technology such as screen readers, etc.
[WARN]  web-api:WebClient:0 Additionally, the attachment-level `fallback` argument is missing in the request payload for a chat.postMessage call - To avoid this warning, it is recommended to always provide a top-level `text` argument when posting a message. Alternatively, you can provide an attachment-level `fallback` argument, though this is now considered a legacy field (see https://api.slack.com/reference/messaging/attachments#legacy_fields for more details).
Error:   web-api:WebClient:0 failed to match all allowed schemas [json-pointer:/attachments/0/blocks/1/fields/3]
Error:   web-api:WebClient:0 must be more than 0 characters [json-pointer:/attachments/0/blocks/1/fields/3/text]
Error: Error: An API error occurred: invalid_attachments
```