### PR TITLE
Add iam-project group to websre newrelic IAM-1253

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3826,6 +3826,7 @@ apps:
     authorized_groups:
     - mozilliansorg_web-sre-aws-access
     - mozilliansorg_pocket_backend
+    - mozilliansorg_iam-project
     authorized_users: []
     client_id: tAtVU4uyJhaXdMEglSWKxMHliBm9yYtS
     display: true


### PR DESCRIPTION
Grants iam team access to green sre team new relic so they may access IAM monitoring.