### PR TITLE
IAM-896: Expensify apps.yml entries are not in a valid state

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3714,18 +3714,6 @@ apps:
     - team_mofo
     authorized_users:
     - billing@mozilla.com
-    client_id: 6BLpfXP845A8yris7DaPST25HycC7l2u
-    display: false
-    logo: auth0.png
-    name: Expensify (getpocket.com)
-    op: auth0
-    url: https://www.expensify.com/authentication/saml/loginCallback?domain=getpocket.com
-- application:
-    authorized_groups:
-    - team_moco
-    - team_mofo
-    authorized_users:
-    - billing@mozilla.com
     client_id: adMlV8Ud0Z77GLfsaa4fb4oQj8ggf0ws
     display: false
     logo: auth0.png

--- a/apps.yml
+++ b/apps.yml
@@ -3710,18 +3710,6 @@ apps:
     - /expensify
 - application:
     authorized_groups:
-    - team_moco
-    - team_mofo
-    authorized_users:
-    - billing@mozilla.com
-    client_id: adMlV8Ud0Z77GLfsaa4fb4oQj8ggf0ws
-    display: false
-    logo: auth0.png
-    name: Expensify
-    op: auth0
-    url: https://www.expensify.com/authentication/saml/loginCallback?domain=mozilla.com
-- application:
-    authorized_groups:
     - mozilliansorg_security_threat_intel
     - mozilliansorg_rapid7_access
     authorized_users: []


### PR DESCRIPTION
Removes the decommed Pocket Expensify entry and a redundant entry for the primary one.

IAM-896