### PR TITLE
add a note about auth0 ldap-only

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,2 @@
 - [x] All PRs are assigned to the review team automatically.
-- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached.
+- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.


### PR DESCRIPTION
Update the PR template quickref for new integrations, to check that Auth0 connections enable only LDAP and not other methods.