### PR TITLE
Upload only apps.yml and set cache control on objct

### DIFF
--- a/.github/workflows/google-deploy.yaml
+++ b/.github/workflows/google-deploy.yaml
@@ -47,8 +47,10 @@ jobs:
         id: 'upload-to-bucket'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
-          path: './'
+          path: '/apps.yml'
           destination: '${{ env.BUCKET_NAME }}'
+          headers: |-
+            cache-control: no-cache
 
       - name: Update slack deployment complete
         if: success()

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ test:
 
 .PHONY: deploy
 deploy: test
-	aws s3 sync . s3://$(S3_BUCKET) --acl public-read
+	aws s3 cp apps.yml s3://$(S3_BUCKET) --acl public-read --cache-control "no-cache"


### PR DESCRIPTION
This PR changes the uploading of apps.yml.  We no longer sync the entire directory and instead only upload the `apps.yml` file.  We also apply the `Cache-Control: no-cache` header to the object.
