### PR TITLE
updated authorized groups to team_moco

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3850,7 +3850,7 @@ apps:
     - /supabase
 - application:
     authorized_groups:
-    - mozilliansorg_dualo-access
+    - team_moco
     authorized_users: []
     client_id: lREe0wwQvrFGwjIaSfrYLBuwAUUF8BOt
     display: true


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
