### PR TITLE
add checkout@v4 to upload-images-to-bucket step

### DIFF
--- a/.github/workflows/google-deploy.yaml
+++ b/.github/workflows/google-deploy.yaml
@@ -54,6 +54,7 @@ jobs:
 
       - name: 'Upload images to CDN bucket'
         id: 'upload-images-to-bucket'
+        uses: 'actions/checkout@v4'
         uses: 'google-github-actions/upload-cloud-storage@v2'
         with:
           path: './images'


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
