### PR TITLE
Add Webcompat Dashboard (dev)

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -1653,6 +1653,16 @@ apps:
 - application:
     authorized_groups:
     - team_moco
+    authorized_users: []
+    client_id: pViyy2GZD7AC9T7khbJnSt1cPbo4R0Ka
+    display: false
+    logo: auth0.png
+    name: Webcompat Dashboard (dev)
+    op: auth0
+    url: https://dev.webcompat.nonprod.webservices.mozgcp.net/login
+- application:
+    authorized_groups:
+    - team_moco
     - team_mofo
     - mozilliansorg_non-moco-sheriffs-basic
     authorized_users: []


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1886211

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
