### PR TITLE
removed Swoogo 2023 from apps.yml

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3790,17 +3790,6 @@ apps:
     vanity_url:
     - /auth0-mgmt-prod
 - application:
-    AAL: LOW
-    authorized_groups:
-    - everyone
-    authorized_users: []
-    client_id: KEEkMrAaqwh1H3TgnWQmFmSg1dHl7GC8
-    display: false
-    logo: auth0.png
-    name: Swoogo 2023
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/KEEkMrAaqwh1H3TgnWQmFmSg1dHl7GC8
-- application:
     authorized_groups:
     - mozilliansorg_formassembly-access
     authorized_users: []


### PR DESCRIPTION
IAM-1314: removed Swoogo 2023 - last year's all hands registration