### PR TITLE
Add /gcal and /jsm vanity URLs

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -365,6 +365,7 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/smKTjsVVxUJDEkjIftOsP0bop2NWjysa?RelayState=https://calendar.google.com/
     vanity_url:
     - /gcalendar
+    - /gcal
 - application:
     authorized_groups:
     - team_moco
@@ -782,6 +783,7 @@ apps:
     vanity_url:
     - /thehub
     - /servicenow
+    - /jsm
 - application:
     AAL: LOW
     authorized_groups:


### PR DESCRIPTION
Adds a couple of vanity URLs that I guess incorrectly every time.

- [x] All PRs are assigned to the review team automatically.
