### PR TITLE
Adds temp travel user to all Jira entries with matching client_id

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -481,6 +481,21 @@ apps:
     - team_moco
     - team_mofo
     - team_mzla
+    - service_jira
+    - moc_service_accounts
+    - mozilliansorg_jira_vendors
+    authorized_users: []
+    client_id: LNU9XiEHlgeU07GLt00vx4y9RR7ALsov
+    display: false
+    logo: jira.png
+    name: Jira - Stage
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/LNU9XiEHlgeU07GLt00vx4y9RR7ALsov
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    - team_mzla
     - team_mzai
     - team_mzvc
     - team_mozillaonline
@@ -497,25 +512,11 @@ apps:
     - /jira
 - application:
     authorized_groups:
-    - team_moco
-    - team_mofo
-    - team_mzla
-    - service_jira
-    - moc_service_accounts
-    - mozilliansorg_jira_vendors
-    authorized_users: []
-    client_id: LNU9XiEHlgeU07GLt00vx4y9RR7ALsov
-    display: false
-    logo: jira.png
-    name: Jira - Stage
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/LNU9XiEHlgeU07GLt00vx4y9RR7ALsov
-- application:
-    authorized_groups:
     - IntranetWiki
     - GuestWiki
     - moc_service_accounts
     authorized_users:
+    - t_mmucci@mozilla.com
     - moc+servicenow@mozilla.com
     - moc-sso-monitoring@mozilla.com
     client_id: TKqD0MP8sDeJAc9QC4f5yp2r9qbx5fcZ
@@ -772,6 +773,7 @@ apps:
     - team_office_support
     - moc_service_accounts
     authorized_users:
+    - t_mmucci@mozilla.com
     - moc+servicenow@mozilla.com
     - moc-sso-monitoring@mozilla.com
     - zoomadmin@mozilla.com

--- a/apps.yml
+++ b/apps.yml
@@ -481,21 +481,6 @@ apps:
     - team_moco
     - team_mofo
     - team_mzla
-    - service_jira
-    - moc_service_accounts
-    - mozilliansorg_jira_vendors
-    authorized_users: []
-    client_id: LNU9XiEHlgeU07GLt00vx4y9RR7ALsov
-    display: false
-    logo: jira.png
-    name: Jira - Stage
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/LNU9XiEHlgeU07GLt00vx4y9RR7ALsov
-- application:
-    authorized_groups:
-    - team_moco
-    - team_mofo
-    - team_mzla
     - team_mzai
     - team_mzvc
     - team_mozillaonline
@@ -510,6 +495,21 @@ apps:
     url: https://mozilla-hub.atlassian.net/jira
     vanity_url:
     - /jira
+- application:
+    authorized_groups:
+    - team_moco
+    - team_mofo
+    - team_mzla
+    - service_jira
+    - moc_service_accounts
+    - mozilliansorg_jira_vendors
+    authorized_users: []
+    client_id: LNU9XiEHlgeU07GLt00vx4y9RR7ALsov
+    display: false
+    logo: jira.png
+    name: Jira - Stage
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/LNU9XiEHlgeU07GLt00vx4y9RR7ALsov
 - application:
     authorized_groups:
     - IntranetWiki


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

To hopefully address the issue with a travel account exception.