### PR TITLE
Add LDAP group travelling_accounts_jira

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -500,8 +500,8 @@ apps:
     - team_mzvc
     - team_mozillaonline
     - team_office_support
-    authorized_users:
-    - t_mmucci@mozilla.com
+    - travelling_accounts_jira
+    authorized_users: []
     client_id: TKqD0MP8sDeJAc9QC4f5yp2r9qbx5fcZ
     display: true
     logo: jira.png
@@ -515,8 +515,8 @@ apps:
     - IntranetWiki
     - GuestWiki
     - moc_service_accounts
+    - travelling_accounts_jira
     authorized_users:
-    - t_mmucci@mozilla.com
     - moc+servicenow@mozilla.com
     - moc-sso-monitoring@mozilla.com
     client_id: TKqD0MP8sDeJAc9QC4f5yp2r9qbx5fcZ
@@ -771,9 +771,9 @@ apps:
     - team_mozillajapan
     - team_mozillaonline
     - team_office_support
+    - travelling_accounts_jira
     - moc_service_accounts
     authorized_users:
-    - t_mmucci@mozilla.com
     - moc+servicenow@mozilla.com
     - moc-sso-monitoring@mozilla.com
     - zoomadmin@mozilla.com


### PR DESCRIPTION
We are in a limbo state where Security has begun allowing travelling accounts to access Jira as one-offs, but at the same time we don't have a solid policy on allowing EVERY travelling account to access Jira.  This is a stand-in group so that we can easily allow this.  If a policy change happens, we can `s/_jira//` later.

(No issue on file, this stems from verbal discussions)

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
