### PR TITLE
fix: update balrog prod url and remove balrog dev

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -1558,7 +1558,7 @@ apps:
     logo: balrog.png
     name: Balrog (Prod)
     op: auth0
-    url: https://aus4-admin.mozilla.org
+    url: https://balrog.services.mozilla.com
 - application:
     authorized_groups:
     - team_services_ops
@@ -1570,17 +1570,6 @@ apps:
     name: Balrog (Stage)
     op: auth0
     url: https://balrog-admin-static-stage.stage.mozaws.net/
-- application:
-    authorized_groups:
-    - team_services_ops
-    - balrog
-    authorized_users: []
-    client_id: MiCmQACl7ZMdn1lTtYnazMYUFiAYAqbF
-    display: true
-    logo: balrog.png
-    name: Balrog (Dev)
-    op: auth0
-    url: https://balrog-admin.dev.mozaws.net
 - application:
     authorized_groups:
     - team_moco


### PR DESCRIPTION
The "Balrog (prod)" url points to the wrong place, and "Balrog (dev)" hasn't been running for a long time.

- [x] All PRs are assigned to the review team automatically.
- [x] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
