### PR TITLE
Bump versions for GHA modules and unittests

### DIFF
--- a/.github/workflows/google-deploy.yaml
+++ b/.github/workflows/google-deploy.yaml
@@ -23,17 +23,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@v3'
+        uses: 'actions/checkout@v4'
 
       - name: 'Google auth'
         id: 'auth'
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
           service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
 
       - name: Send initial slack notification
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1.26.0
         id: slack
         with:
           channel-id: ${{ env.CHANNEL_IDS }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Update slack deployment complete
         if: success()
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1.26.0
         with:
           update-ts: ${{ steps.slack.outputs.ts }}
           channel-id: ${{ env.CHANNEL_IDS }}
@@ -73,7 +73,7 @@ jobs:
 
       - name: Update slack deployment failed
         if: failure()
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1.26.0
         with:
           update-ts: ${{ steps.slack.outputs.ts }}
           channel-id: ${{ env.CHANNEL_IDS }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.12
     - name: Run tests via Makefile
       run: |
         make test

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ S3_BUCKET	:= ${S3_BUCKET}
 
 .PHONY: test
 test:
-	pip install pyyaml==5.4.1
+	pip install pyyaml==6.0.1
 	python -m unittest discover tests
 
 .PHONY: deploy

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -19,11 +19,11 @@ class YAMLTest(unittest.TestCase):
         assert self.get_yaml_file() is not None
 
     def test_yaml_loads(self):
-        yaml_content = yaml.load(self.get_yaml_file())
+        yaml_content = yaml.load(self.get_yaml_file(), Loader=yaml.SafeLoader)
         assert yaml_content is not None
 
     def test_each_has_required_keys(self):
-        yaml_content = yaml.load(self.get_yaml_file())
+        yaml_content = yaml.load(self.get_yaml_file(), Loader=yaml.SafeLoader)
         assert yaml_content is not None
 
         for app in yaml_content['apps']:


### PR DESCRIPTION
This PR updates versions for various third party Github Actions, the python version for unittesting, and `pyyaml` version used in the unittest.