### PR TITLE
Grant infrasec access to Pocket AWS SSO

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3934,6 +3934,7 @@ apps:
     - mozilliansorg_pocket_sales
     - mozilliansorg_pocket_ads
     - mozilliansorg_pocket_aws_billing
+    - mozilliansorg_infrasec
     authorized_users: []
     client_id: pQ0eb5tzwfYHnAtzGuk88pzxZ68szQtk
     display: true


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/IAM-1367

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
