### PR TITLE
add infrasec per IAM-1358

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3881,6 +3881,7 @@ apps:
     - mozilliansorg_mofo_aws_projects
     - mozilliansorg_mofo_aws_sandbox
     - mozilliansorg_mofo_aws_secure
+    - mozilliansorg_infrasec
     authorized_users: []
     client_id: jU8r4uSEF3fUCjuJ63s46dBnHAfYMYfj
     display: true


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
