### PR TITLE
Slack payload message tweak

### DIFF
--- a/.github/workflows/payload-slack-content.json
+++ b/.github/workflows/payload-slack-content.json
@@ -1,5 +1,5 @@
 {
-  "text": ":link-run:",
+  "text": ":triforce:",
   "attachments": [
     {
       "color": "{{ env.STATUS_COLOR }}",
@@ -8,7 +8,7 @@
           "type": "header",
           "text": {
             "type": "plain_text",
-            "text": ":link-wut: Github Action Notification :link-wut:\n{{ github.workflow }}",
+            "text": "Github Action Notification :navi: :link-wut:",
             "emoji": true
           }
         },
@@ -17,22 +17,22 @@
           "fields": [
             {
               "type": "plain_text",
-              "text": "{{ env.RELEASE_NAME }}",
+              "text": "By: *{{ env.GITHUB_ACTOR }}*",
               "emoji": true
             },
             {
               "type": "plain_text",
-              "text": "{{ env.GITHUB_ACTOR }}",
+              "text": "Repo: *{{ env.GITHUB_REPOSITORY }}*",
               "emoji": true
             },
             {
               "type": "plain_text",
-              "text": "{{ env.GITHUB_REPOSITORY }}",
+              "text": "Tag: *{{ env.GITHUB_REF_NAME }}*",
               "emoji": true
             },
             {
               "type": "plain_text",
-              "text": "{{ env.GITHUB_REF_NAME }}",
+              "text": "Workflow: *{{ github.workflow }}*",
               "emoji": true
             }
           ]


### PR DESCRIPTION
I noticed that ~`env.GITHUB_ACTOR`~ `env.RELEASE_NAME` is always `???` so I tossed that. Reordered the text fields a little, and made the values bold. And moved the workflow name to the empty text field spot.

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
