### PR TITLE
Update LifeLabs URL

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -4235,7 +4235,7 @@ apps:
     logo: lifelabs.png
     name: Mozilla Learning Program
     op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/OWmWq6YwMvc8TwIrMlWzK81KaLZDkOYw
+    url: https://app.lifelabslearning.com/training?sso=Mozilla
     vanity_url:
     - /lifelabs
     - /mlp


### PR DESCRIPTION
They require SP-initiated SSO, thus updating the url.

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
