### PR TITLE
Update Slack payload message (take 2)

### DIFF
--- a/.github/workflows/payload-slack-content.json
+++ b/.github/workflows/payload-slack-content.json
@@ -17,22 +17,22 @@
           "fields": [
             {
               "type": "plain_text",
-              "text": "By: *{{ env.GITHUB_ACTOR }}*",
+              "text": "{{ env.GITHUB_REPOSITORY }}",
               "emoji": true
             },
             {
               "type": "plain_text",
-              "text": "Repo: *{{ env.GITHUB_REPOSITORY }}*",
+              "text": "{{ env.GITHUB_ACTOR }}",
               "emoji": true
             },
             {
-              "type": "plain_text",
+              "type": "mrkdwn",
               "text": "Tag: *{{ env.GITHUB_REF_NAME }}*",
               "emoji": true
             },
             {
               "type": "plain_text",
-              "text": "Workflow: *{{ github.workflow }}*",
+              "text": "{{ github.workflow }}",
               "emoji": true
             }
           ]


### PR DESCRIPTION
Moves `env.GITHUB_REPOSITORY` back to the first column where it shouldn't line wrap, removes the markdown for bold text on the `plain_text` fields, but updates the `env.GITHUB_REF_NAME` field to `mrkdwn` so I can bolden the tag name.

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
