### PR TITLE
IAM-1384 Add Developer Services group to Cloudservices AWS SSO

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -4216,6 +4216,7 @@ apps:
     - mozilliansorg_cloudservices_aws_admin
     - mozilliansorg_cloudservices_aws_autograph_admin
     - mozilliansorg_cloudservices_aws_autograph_dev
+    - mozilliansorg_cloudservices_aws_developer_services_dev
     authorized_users: []
     client_id: c0x6EoLdp55H2g2OXZTIUuaQ4v8U4xf9
     display: true


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
