### PR TITLE
IAM 1370

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -4217,6 +4217,7 @@ apps:
     - mozilliansorg_cloudservices_aws_autograph_admin
     - mozilliansorg_cloudservices_aws_autograph_dev
     - mozilliansorg_cloudservices_aws_developer_services_dev
+    - mozilliansorg_infrasec
     authorized_users: []
     client_id: c0x6EoLdp55H2g2OXZTIUuaQ4v8U4xf9
     display: true

--- a/apps.yml
+++ b/apps.yml
@@ -4216,6 +4216,7 @@ apps:
     - mozilliansorg_cloudservices_aws_admin
     - mozilliansorg_cloudservices_aws_autograph_admin
     - mozilliansorg_cloudservices_aws_autograph_dev
+    - mozilliansorg_cloudservices_aws_developer_services_dev
     authorized_users: []
     client_id: c0x6EoLdp55H2g2OXZTIUuaQ4v8U4xf9
     display: true


### PR DESCRIPTION
- **IAM-1384 Add Developer Services group to Cloudservices AWS SSO**
- **IAM-1370 Add Infrasec group to Cloudservices AWS**

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
