### PR TITLE
IAM-1389 Add FxA developers to Cloudservices AWS

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -4217,6 +4217,7 @@ apps:
     - mozilliansorg_cloudservices_aws_autograph_admin
     - mozilliansorg_cloudservices_aws_autograph_dev
     - mozilliansorg_cloudservices_aws_developer_services_dev
+    - mozilliansorg_cloudservices_aws_fxa_developers
     - mozilliansorg_infrasec
     authorized_users: []
     client_id: c0x6EoLdp55H2g2OXZTIUuaQ4v8U4xf9


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
