### PR TITLE
Initial entry for Slack Enterprise

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -4264,3 +4264,15 @@ apps:
     name: Nemo Grafana
     op: auth0
     url: https://nemo.mozilla.net/grafana/
+- application:
+    authorized_groups: []
+    authorized_users:
+    - cbrentano@mozilla.com
+    - mrudland@mozilla.com
+    client_id: htnpYVQ6jsBnxstKeETNerYgVUjvE7SB
+    display: false
+    logo: slack.png
+    name: Slack Enterprise
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/htnpYVQ6jsBnxstKeETNerYgVUjvE7SB
+    vanity_url:


### PR DESCRIPTION
Omitted 'Grid' from the name since it will probably get cut-off and look like "Slack Enterprise Gr...", also it's not super relevant for end users.

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

This will let me gate access to just Michele and I while I get SSO ready for the migration.