### PR TITLE
Switch to using a group for early access

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -4265,10 +4265,19 @@ apps:
     op: auth0
     url: https://nemo.mozilla.net/grafana/
 - application:
-    authorized_groups: []
-    authorized_users:
-    - cbrentano@mozilla.com
-    - mrudland@mozilla.com
+    authorized_groups:
+    - mozilliansorg_slackeg-access
+    # These will be enabled when we're ready to switch over:
+    #- mozilliansorg_slack-access
+    #- team_moco
+    #- team_mofo
+    #- team_mzla
+    #- team_mzai
+    #- team_mzvc
+    #- team_mozillaonline
+    #- travelling_accounts
+    #- team_office_support    
+    authorized_users: []
     client_id: htnpYVQ6jsBnxstKeETNerYgVUjvE7SB
     display: false
     logo: slack.png


### PR DESCRIPTION
And stage the remaining groups (commented out) for when the time comes to switch.

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
