### PR TITLE
Update test cases for `vanity_url` IAM-1399

### DIFF
--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,6 +1,7 @@
 "Test the YAML file is loadable and valid"
 import logging
 import unittest
+import re
 import yaml
 
 
@@ -38,3 +39,12 @@ class YAMLTest(unittest.TestCase):
             assert app['application']['display'] is not None
             if app['application'].get('expire_access_when_unused_after') is not None:
                 assert isinstance(app['application']['expire_access_when_unused_after'], int)
+            if 'vanity_url' in app['application']:
+                # deliberate 'test-then-get' to detect a case of "key but no value" as
+                # opposed to .get() returning a None.
+                vanity_urls_raw = app['application']['vanity_url']
+                assert isinstance(vanity_urls_raw, list)
+                assert len(vanity_urls_raw) > 0
+                for vanity_url_raw in vanity_urls_raw:
+                    assert isinstance(vanity_url_raw, str)
+                    assert re.match(r'^/', vanity_url_raw)

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -10,10 +10,10 @@ logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
 
 class YAMLTest(unittest.TestCase):
     def get_yaml_file(self):
-        apps_yml = open('apps.yml')
-        contents = apps_yml.read()
-        apps_yml.close()
-        return contents
+        with open('apps.yml', encoding='utf-8') as apps_yml:
+            contents = apps_yml.read()
+            apps_yml.close()
+            return contents
 
     def test_output_exists(self):
         assert self.get_yaml_file() is not None
@@ -27,7 +27,7 @@ class YAMLTest(unittest.TestCase):
         assert yaml_content is not None
 
         for app in yaml_content['apps']:
-            logger.info('Validating keys for {}'.format(app['application']))
+            logger.info('Validating keys for %s', app['application'])
             assert app['application']['name'] is not None
             # assert app['application']['client_id'] is not None # Client ID not required
             assert app['application']['op'] is not None


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
