### PR TITLE
Remove `expire_access_when_unused_after`, IAM-1267

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.0.1] - 2018-05-24
 ### Added
-- Support for `expire_access_when_unused_after`
+- Support for `expire_access_when_unused_after`  (removed after 2024)
 
 ## [1.0.0] - 2018-02-26
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,11 +55,6 @@ This is a list of available fields.
       authorized_users: []
       authorized_groups: []
 
-      # How many seconds before a user who has logged into this RP is denied access. The timer reset for each login,
-      # thus access is only denied if you haven't logged in at all for this period of time. Is it enforced by the Access
-      # Provider
-      expire_access_when_unused_after: 7776000
-
       ## Mappings to standard levels (https://infosec.mozilla.org/guidelines/risk/standard_levels) AAL
       ## values below are available at the IAM well-known endpoint
       ## (https://auth.mozilla.org/.well-known/mozilla-iam)

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -82,10 +82,6 @@ class YAMLTest(unittest.TestCase):
             assert app['display'] is not None
             assert isinstance(app['display'], bool)
             ####################################################################################
-            if 'expire_access_when_unused_after' in app:
-                assert isinstance(app['expire_access_when_unused_after'], int)
-                assert app['expire_access_when_unused_after'] > 0
-            ####################################################################################
             if 'vanity_url' in app:
                 # deliberate 'test-then-get' to detect a case of "key but no value" as
                 # opposed to .get() returning a None.


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
