### PR TITLE
Add infrasec to AWS - IT

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3613,6 +3613,7 @@ apps:
     - mozilliansorg_devtools-code-origin-access
     - mozilliansorg_iam-in-transition
     - mozilliansorg_iam-in-transition-admin
+    - mozilliansorg_infrasec
     - mozilliansorg_meao-admins
     - mozilliansorg_mozilla-moderator-devs
     - mozilliansorg_partinfra-aws


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

Concomitant with https://github.com/mozilla-iam/aws-iam-identity-center-management/pull/6