### PR TITLE
Add lifelabs-access group for edge cases per IAM-1374

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -4027,6 +4027,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_elance
+    - mozilliansorg_lifelabs-access
     authorized_users: []
     client_id: OWmWq6YwMvc8TwIrMlWzK81KaLZDkOYw
     display: true


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

There are a large handful of managers who need SSO access who aren't already in `team_moco` or `team_elance`, so this group is for them.
