### PR TITLE
Remove authorized groups in `apps.yml` for deleted AWS accounts from …

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3599,9 +3599,6 @@ apps:
     - aws_320464205386_admin
     - aws_320464205386_read_only
     - aws_359555865025_admin
-    - aws_558986605633_admin
-    - aws_622567216674_admin
-    - aws_839739216564_admin
     - aws_consolidatedbilling_admin
     - aws_consolidatedbilling_read_only
     - aws_discourse_dev


### PR DESCRIPTION
…`aws-it` application

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
