### PR TITLE
Add team_mzla to zendesk, verbal request in servicedesk

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -1446,6 +1446,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
+    - team_mzla
     authorized_users: []
     client_id: zk9N7LU2ihMIy0bwlGd7GfRVXDKsGQjI
     display: false


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
