### PR TITLE
Revert "Add team_mzla to zendesk, verbal request in servicedesk"

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -1425,7 +1425,6 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - team_mzla
     authorized_users: []
     client_id: zk9N7LU2ihMIy0bwlGd7GfRVXDKsGQjI
     display: false


### PR DESCRIPTION
This reverts commit 2df64a47aedf5edf07583c9a6702ed64e8a5f348.

MZLA can't have access to zendesk without a direct agreement, the current contract is insufficient for partner access.

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
