### PR TITLE
Revert "Add infrasec (#825)"

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3547,7 +3547,6 @@ apps:
     - mozilliansorg_devtools-code-origin-access
     - mozilliansorg_iam-in-transition
     - mozilliansorg_iam-in-transition-admin
-    - mozilliansorg_infrasec
     - mozilliansorg_meao-admins
     - mozilliansorg_mozilla-moderator-devs
     - mozilliansorg_partinfra-aws


### PR DESCRIPTION
This reverts commit 06e4968fdee6984ecd977a88485722d4734906ac.

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

Per recent discussion in IAM-1410 this is no longer needed, thus reverting.