### PR TITLE
Remove pad.m.o, IAM-1441

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -2226,17 +2226,6 @@ apps:
     op: auth0
     url: https://auth.mozilla.auth0.com/samlp/SJmdyaeuz4SkdoWgOXZxVFeQukpt5SMo
 - application:
-    AAL: LOW
-    authorized_groups:
-    - everyone
-    authorized_users: []
-    client_id: TSYr6tZcybHxtOlYznB1fslCvCInnKw3
-    display: false
-    logo: auth0.png
-    name: pad.mozilla.org
-    op: auth0
-    url: https://pad.mozilla.org/openid/callback/login
-- application:
     authorized_groups:
     - team_moco
     - team_mofo


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
