### PR TITLE
Adding mozilliansorg_sre group to AWS

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3542,6 +3542,7 @@ apps:
     - mozilliansorg_pocket_cloudtrail_readers
     - mozilliansorg_searchfox-aws
     - mozilliansorg_secops-aws-admins
+    - mozilliansorg_sre
     - mozilliansorg_voice_aws_admin_access
     - mozilliansorg_web-sre-aws-access
     - team_infra


### PR DESCRIPTION
Jira: IAM-1453

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
