### PR TITLE
Add mozilliansorg_pocket_fin_ops to Pocket's AWS

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3575,6 +3575,7 @@ apps:
     - mozilliansorg_pocket_dataanalytics
     - mozilliansorg_pocket_datalearning
     - mozilliansorg_pocket_developer
+    - mozilliansorg_pocket_fin_ops
     - mozilliansorg_pocket_frontend
     - mozilliansorg_pocket_marketing
     - mozilliansorg_pocket_mozilla_sre


### PR DESCRIPTION
Jira: [OPS-1470](https://mozilla-hub.atlassian.net/browse/IAM-1470)

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
