### PR TITLE
Add mozilliansorg_relay_developer (AWS-IT)

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3547,6 +3547,7 @@ apps:
     - mozilliansorg_sre
     - mozilliansorg_sumo-admins
     - mozilliansorg_sumo-devs
+    - mozilliansorg_relay_developer
     - mozilliansorg_voice_aws_admin_access
     - mozilliansorg_web-sre-aws-access
     - team_mdn


### PR DESCRIPTION
Jira: [IAM-1505](https://mozilla-hub.atlassian.net/browse/IAM-1505), [IAM-1512](https://mozilla-hub.atlassian.net/browse/IAM-1512)

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.


See also:

* mozilla-iam/aws-iam-identity-center-management#22
* mozilla-iam/auth0-deploy#485