### PR TITLE
Groups are being migrated to peoplemo

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -863,7 +863,9 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/uMkOuQX8LGTxAyYIiX4eLoc4hl0pWSJt
 - application:
     authorized_groups:
+    # Replaced by mozilliansorg_iam-admins.
     - aws_320464205386_admin
+    - mozilliansorg_iam-admins
     authorized_users: ['hcondei@mozilla.com']
     client_id: nlE73wPPuOaN0wAYKWY6QD3VcjUStehZ
     display: false
@@ -2250,7 +2252,9 @@ apps:
     url: https://virgo-b.fuzzing.mozilla.org/
 - application:
     authorized_groups:
+    # Replaced by mozilliansorg_iam-admins.
     - aws_320464205386_admin
+    - mozilliansorg_iam-admins
     authorized_users: []
     client_id: LuNrrJpcnK2Nlh75wRJ2ab6gxEJYFMQG
     display: false
@@ -3523,33 +3527,47 @@ apps:
 - application:
     authorized_groups:
     # TODO(bhee): delete as a part of https://mozilla-hub.atlassian.net/browse/IAM-1474
+    # Replaced by mozilliansorg_sumo-admins and mozilliansorg_sumo-devs.
     - aws_095732026120_poweruser
+    # Replaced by mozillians_project-guardian-admins.
     - aws_104923852476_admin
+    # Replaced by mozilliansorg_iam-admins.
     - aws_320464205386_admin
+    # Replaced by mozilliansorg_iam-readonly.
     - aws_320464205386_read_only
+    # Replaced by mozilliansorg_webcompat-alexa-admins.
     - aws_359555865025_admin
+    # Replaced by mozilliansorg_consolidated-billing-aws.
     - aws_consolidatedbilling_admin
+    # Replaced by mozilliansorg_consolidated-billing-aws-readonly.
     - aws_consolidatedbilling_read_only
+    # Replaced by mozilliansorg_discourse-devs.
     - aws_discourse_dev
     - fuzzing_team
+    - mozillians_project-guardian-admins
     - mozilliansorg_aws_billing_access
     - mozilliansorg_cia-aws
     - mozilliansorg_consolidated-billing-aws
+    - mozilliansorg_consolidated-billing-aws-readonly
+    - mozilliansorg_discourse-devs
+    - mozilliansorg_iam-admins
     - mozilliansorg_iam-in-transition
     - mozilliansorg_iam-in-transition-admin
+    - mozilliansorg_iam-readonly
     - mozilliansorg_meao-admins
     - mozilliansorg_mozilla-moderator-devs
     - mozilliansorg_partinfra-aws
     - mozilliansorg_pdfjs-testers
     - mozilliansorg_pocket_cloudtrail_readers
+    - mozilliansorg_relay_developer
     - mozilliansorg_searchfox-aws
     - mozilliansorg_secops-aws-admins
     - mozilliansorg_sre
     - mozilliansorg_sumo-admins
     - mozilliansorg_sumo-devs
-    - mozilliansorg_relay_developer
     - mozilliansorg_voice_aws_admin_access
     - mozilliansorg_web-sre-aws-access
+    - mozilliansorg_webcompat-alexa-admins
     - team_mdn
     - team_netops
     - team_opsec


### PR DESCRIPTION
In particular:

* aws_095732026120_poweruser (completed previously, see 6ba2a5)
* aws_104923852476_admin -> project-guardian-admins
* aws_320464205386_admin -> iam-admins
* aws_320464205386_read_only -> iam-readonly
* aws_359555865025_admin -> webcompat-alexa-admins
* aws_consolidatedbilling_admin -> consolidated-billing-aws (this group existed already, though the membership was different)
* aws_consolidatedbilling_read_only -> consolidated-billing-aws-readonly
* aws_discourse_dev -> created discourse-devs

Jira: [IAM-1460](https://mozilla-hub.atlassian.net/browse/IAM-1460)

See also:

* https://github.com/mozilla-iam/aws-iam-identity-center-management/pull/24
* https://github.com/mozilla-iam/auth0-deploy/pull/486

---

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
