### PR TITLE
Remove groups which have been replaced in peoplemo

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -863,8 +863,6 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/uMkOuQX8LGTxAyYIiX4eLoc4hl0pWSJt
 - application:
     authorized_groups:
-    # Replaced by mozilliansorg_iam-admins.
-    - aws_320464205386_admin
     - mozilliansorg_iam-admins
     authorized_users: ['hcondei@mozilla.com']
     client_id: nlE73wPPuOaN0wAYKWY6QD3VcjUStehZ
@@ -2252,8 +2250,6 @@ apps:
     url: https://virgo-b.fuzzing.mozilla.org/
 - application:
     authorized_groups:
-    # Replaced by mozilliansorg_iam-admins.
-    - aws_320464205386_admin
     - mozilliansorg_iam-admins
     authorized_users: []
     client_id: LuNrrJpcnK2Nlh75wRJ2ab6gxEJYFMQG
@@ -3526,23 +3522,6 @@ apps:
     url: http://127.0.0.1:8000/oidc/callback/
 - application:
     authorized_groups:
-    # TODO(bhee): delete as a part of https://mozilla-hub.atlassian.net/browse/IAM-1474
-    # Replaced by mozilliansorg_sumo-admins and mozilliansorg_sumo-devs.
-    - aws_095732026120_poweruser
-    # Replaced by mozillians_project-guardian-admins.
-    - aws_104923852476_admin
-    # Replaced by mozilliansorg_iam-admins.
-    - aws_320464205386_admin
-    # Replaced by mozilliansorg_iam-readonly.
-    - aws_320464205386_read_only
-    # Replaced by mozilliansorg_webcompat-alexa-admins.
-    - aws_359555865025_admin
-    # Replaced by mozilliansorg_consolidated-billing-aws.
-    - aws_consolidatedbilling_admin
-    # Replaced by mozilliansorg_consolidated-billing-aws-readonly.
-    - aws_consolidatedbilling_read_only
-    # Replaced by mozilliansorg_discourse-devs.
-    - aws_discourse_dev
     - fuzzing_team
     - mozillians_project-guardian-admins
     - mozilliansorg_aws_billing_access


### PR DESCRIPTION
Jira: IAM-1474

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
