### PR TITLE
updated fable authorized groups

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -4113,6 +4113,7 @@ apps:
     - /fastly
 - application:
     authorized_groups:
+    - team_moco
     - mozilliansorg_fable-access
     authorized_users: []
     client_id: DlyjWdZjRtd3bRTplD2akcW5xOEWRqTI


### PR DESCRIPTION
IAM-1517: updated access for Fable app; left access group intact should individuals outside moco get invited.