### PR TITLE
Add AWS access for cloudservices_aws_taskcluster_devs

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3899,6 +3899,7 @@ apps:
     - mozilliansorg_cloudservices_aws_dev_developers
     - mozilliansorg_cloudservices_aws_developer_services_dev
     - mozilliansorg_cloudservices_aws_fxa_developers
+    - mozilliansorg_cloudservices_aws_taskcluster_devs
     - mozilliansorg_infrasec
     authorized_users: []
     client_id: c0x6EoLdp55H2g2OXZTIUuaQ4v8U4xf9


### PR DESCRIPTION
Jira: [IAM-1545](https://mozilla-hub.atlassian.net/browse/IAM-1545)

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
