### PR TITLE
Add service_jira as an authorized group for Jira products, IAM-1580

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -442,6 +442,7 @@ apps:
     - team_mzvc
     - team_mozillaonline
     - team_office_support
+    - service_jira
     - travelling_accounts_jira
     authorized_users: []
     client_id: TKqD0MP8sDeJAc9QC4f5yp2r9qbx5fcZ
@@ -463,6 +464,7 @@ apps:
     - team_mozillaonline
     - team_office_support
     - moc_service_accounts
+    - service_jira
     - travelling_accounts_jira
     authorized_users:
     - moc+servicenow@mozilla.com
@@ -688,6 +690,7 @@ apps:
     - team_mozillajapan
     - team_mozillaonline
     - team_office_support
+    - service_jira
     - travelling_accounts_jira
     - moc_service_accounts
     authorized_users:


### PR DESCRIPTION
This supports non-moco users having a path to access, notably driving this is a test account.

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
