### PR TITLE
removed team_mzvc from airmo

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -130,7 +130,6 @@ apps:
     - team_mofo
     - team_mzla
     - team_mzai
-    - team_mzvc
     - team_mozillaonline
     - mozilliansorg_nda
     authorized_users: []


### PR DESCRIPTION
IAM-1604: removed team_mzvc from Air Mozilla.