### PR TITLE
remove Web SRE Papetrail entry

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -2714,18 +2714,6 @@ apps:
     - /learnerbly
 - application:
     authorized_groups:
-    - mozilliansorg_web-sre-papertrail-access
-    authorized_users: []
-    client_id: QSbhAzqUlqCSWt6iAV45um5DDGdhhDTR
-    display: true
-    logo: papertrail-logo.png
-    name: Papertrail Web SRE
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/QSbhAzqUlqCSWt6iAV45um5DDGdhhDTR
-    vanity_url:
-    - /papertrail-websre
-- application:
-    authorized_groups:
     - team_moco
     authorized_users: []
     client_id: 6T3nWVBk9uTyzXSGfxq21UtZ3jAaracA


### PR DESCRIPTION
We're shutting down the Web SRE Papertrail tenant, so we should remove this entry.

https://mozilla-hub.atlassian.net/browse/OBS-431

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
