### PR TITLE
ci url output had trailing spaces, which fails yaml linting

### DIFF
--- a/tools/lint-apps
+++ b/tools/lint-apps
@@ -24,10 +24,15 @@ def apps_from_yml(filename) -> Any:
         return yaml.load(handle)
 
 
+def no_trailing_spaces_for_urls(line: str) -> str:
+    """We'll fail pre-commit's yaml linting otherwise."""
+    return line.replace("  url: \n", "  url:\n")
+
+
 def apps_to_yml(apps: Any) -> None:
     yaml = YAML(typ="rt")
     with open(APPS_NEW_YML, "w") as handle:
-        yaml.dump(apps, handle)
+        yaml.dump(apps, handle, transform=no_trailing_spaces_for_urls)
 
 
 def apps_from_auth0():


### PR DESCRIPTION
Jira: [IAM-950](https://mozilla-hub.atlassian.net/browse/IAM-950)

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
