### PR TITLE
added 2 new groups to Splunk SC access

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -2719,6 +2719,8 @@ apps:
     - mozilliansorg_sec_splunk_netops
     - mozilliansorg_sec_splunk_ir
     - mozilliansorg_sec_splunk_infrasec
+    - mozilliansorg_sec_splunk_netlify
+    - mozilliansorg_sec_splunk_relsre
     authorized_users: []
     client_id: oU7d3KS3RqCYDFprG0nQD7eBPeO7uWyl
     display: true


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
