### PR TITLE
Update mozilla foundation sso login url

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -4175,7 +4175,7 @@ apps:
     logo: wagtail.png
     name: Website CMS (MoFo)
     op: auth0
-    url: https://foundation.mozilla.org/soc/login/auth0/?next=/cms
+    url: https://www.mozillafoundation.org/soc/login/auth0/?next=/cms
 - application:
     authorized_groups:
     - team_moco


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

We've swapped domains to www.mozillafoundation.org. This PR updates the sso login url for the mozilla foundation website