### PR TITLE
Add monitor accounts

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3307,6 +3307,8 @@ apps:
     - mozilliansorg_iam-in-transition-admin
     - mozilliansorg_iam-readonly
     - mozilliansorg_meao-admins
+    - mozilliansorg_monitor_nonprod_aws_devs
+    - mozilliansorg_monitor_prod_aws_devs
     - mozilliansorg_mozilla-moderator-devs
     - mozilliansorg_partinfra-aws
     - mozilliansorg_pdfjs-testers


### PR DESCRIPTION
Jira: [OPST-2515](https://mozilla-hub.atlassian.net/browse/OPST-2515)

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

See also:

* https://github.com/mozilla-iam/aws-iam-identity-center-management/pull/32