### PR TITLE
Remove team_pocket from Navan access

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -2574,7 +2574,6 @@ apps:
     - team_mzla
     - team_mzai
     - team_mzvc
-    - team_pocket
     - team_mozillaonline
     authorized_users: []
     client_id: i1qBrMjJEdKlTNEVgGwc9P0xFxI9cuD8
@@ -6061,7 +6060,6 @@ apps:
     - team_mzla
     - team_mzai
     - team_mzvc
-    - team_pocket
     - team_mozillaonline
     authorized_users: []
     client_id: TwZ8Ux43hO2h1gi5GwUvEJVnJ20icd9S


### PR DESCRIPTION
bug 1707014 added `team_pocket` to egencia/tripactions/navan.  At the time (2021), `team_pocket` was all pocket people, and they were distinct from MoCo/MoFo.  Since then, Pocket is all integrated with MoCo, and as such this team group is unnecessary for Navan.

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
