### PR TITLE
removed testing access group

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -2451,7 +2451,6 @@ apps:
 - application:
     authorized_groups:
     - team_mzla
-    - mozilliansorg_onboard-testing
     authorized_users: []
     client_id: aXMgLIHosl6m35hT1zJoTHmGWzAbREJj
     display: true


### PR DESCRIPTION
IAM-1693: removed access group used for testing. Udemy-MZLA should be fully onboarded now.