### PR TITLE
Disabled webhook builds, so we need a manual trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,21 @@ make test
 
 # CI Pipeline
 
-This GitHub repo has a webhook configured which triggers the `apps_yml` AWS
-CodeBuild job in the `mozilla-iam` AWS account in `us-west-2`. This CodeBuild
-job follows the [`buildspec.yml`](buildspec.yml) which calls [`deploy.sh`](deploy.sh)
-to deploy the change.
+The CI Pipeline has been disabled for now, until we can revive it. Deploys will
+need to be manual.
+
+To deploy the `master` branch, run:
+
+```
+AWS_PROFILE=iam-admin aws codebuild start-build \
+    --project-name apps_yml \
+    --environment-variables-override 'name=MANUAL_DEPLOY_TRIGGER,value=branch/master'
+```
+
+To deploy a release, run:
+
+```
+AWS_PROFILE=iam-admin aws codebuild start-build \
+    --project-name apps_yml \
+    --environment-variables-override 'name=MANUAL_DEPLOY_TRIGGER,value=tags/<tag>'
+```

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
 
+TRIGGER=${CODEBUILD_WEBHOOK_TRIGGER:-${MANUAL_DEPLOY_TRIGGER:-}}
+
 echo "Begin deploy of the apps.yml file."
-echo "$CODEBUILD_WEBHOOK_TRIGGER"
+echo "Webhook trigger: ${CODEBUILD_WEBHOOK_TRIGGER:-None}"
+echo "Manual deploy trigger: ${MANUAL_DEPLOY_TRIGGER:-None}"
+echo "Effective trigger: $TRIGGER"
 
-
-if [[ "branch/master" == "$CODEBUILD_WEBHOOK_TRIGGER" ]]
-	then
+if [[ "$TRIGGER" == "branch/master" ]]; then
 		echo "Deploying to the development CDN cdn.sso.allizom.org"
         make deploy S3_BUCKET=sso-dashboard.configuration
-elif [[ "$CODEBUILD_WEBHOOK_TRIGGER" =~ ^tag\/[0-9]+\.[0-9]+\.[0-9]+(\-(prod))?$ ]]
-	then
+elif [[ "$TRIGGER" =~ ^tag\/[0-9]+\.[0-9]+\.[0-9]+(\-(prod))?$ ]]; then
 		echo "Deploying to the production CDN cdn.sso.mozilla.com"
         make deploy S3_BUCKET=sso-dashboard.configuration-prod
 fi
 
-
-echo "$CODEBUILD_WEBHOOK_TRIGGER"
 echo "End deploy of the apps.yml."


### PR DESCRIPTION
This will have to suffice in the mean time, while we revamp this pipeline.

Jira: [IAM-1729](https://mozilla-hub.atlassian.net/browse/IAM-1729)

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
