### PR TITLE
Update repo badge to current GH CI test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # sso-dashboard-configuration
 
-![Build Status](https://github.com/mozilla-iam/sso-dashboard-configuration/workflows/Test%20Configuration/badge.svg)
+[![GitHub test status](https://github.com/mozilla-iam/sso-dashboard-configuration/actions/workflows/main.yaml/badge.svg)](https://github.com/mozilla-iam/sso-dashboard-configuration/actions/workflows/main.yaml)
 
-![Codebuild Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiUWVHQlJNT2FjckNEcUFtUzI4VVR3ZlBTYjRCYnl4SWhWcUx0TTFEMUMzWmFMM3N2eGdLOFJMTUl6NkNtQTFkRVdXa2RzSEQ5SGYvZWRZMW01Q2cvcXhRPSIsIml2UGFyYW1ldGVyU3BlYyI6IjZjWmVyRWdkRDFFVTllRksiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![CodeBuild status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiUWVHQlJNT2FjckNEcUFtUzI4VVR3ZlBTYjRCYnl4SWhWcUx0TTFEMUMzWmFMM3N2eGdLOFJMTUl6NkNtQTFkRVdXa2RzSEQ5SGYvZWRZMW01Q2cvcXhRPSIsIml2UGFyYW1ldGVyU3BlYyI6IjZjWmVyRWdkRDFFVTllRksiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 
 # How it works...
 


### PR DESCRIPTION
chore: Updates the readme CI badge to show current status of "Main workflow" GitHub Actions pipeline that now is the place to contain "Test Dashboard Configuration / Test Configuration" job/callable and a deployment job after it.

(Also fixes some term casing with no impact on output.)

NB: The workflow name is used for the badge render, so if a different label would be more appropriate, the name key of the workflow file would have to change to bubble up here too.

👓 Preview: [janbrasna/sso-dashboard-configuration#readme](https://github.com/janbrasna/sso-dashboard-configuration/tree/readme-ci#readme)