### PR TITLE
Decom WDE, IO-3208

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -1550,17 +1550,6 @@ apps:
     - team_moco
     - team_mofo
     authorized_users: []
-    client_id: hIjZmDmmtkKuaOjmhd5HUzn0ResPDeqX
-    display: false
-    logo: auth0.png
-    name: wde.allizom.org
-    op: auth0
-    url: https://wde-stage.public.mdc1.mozilla.com/redirect_uri
-- application:
-    authorized_groups:
-    - team_moco
-    - team_mofo
-    authorized_users: []
     client_id: 1QcjRY2UEYySI79IqorH94Td590oqXSA
     display: false
     logo: auth0.png
@@ -2033,17 +2022,6 @@ apps:
     name: Logging 2.0 CEP Prod
     op: auth0
     url: https://logging-cep.prod.mozaws.net/dashboard_output/login
-- application:
-    authorized_groups:
-    - team_moco
-    - team_mofo
-    authorized_users: []
-    client_id: BDRmLMBwmCqyBsL52IuQW8wLBLoLSBWo
-    display: false
-    logo: auth0.png
-    name: wde.mozilla.org
-    op: auth0
-    url: https://wde.mozilla.org/redirect_uri
 - application:
     authorized_groups:
     - team_moco


### PR DESCRIPTION
I decom'ed WDE stage a long time ago, and prod 3 months ago.  I missed that there was an SSO component lying around.

Please zap the auth0 apps and the config.  No rush.  Thanks!


- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.