### PR TITLE
Add meao-admins to the cloudservices section

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3608,6 +3608,7 @@ apps:
     - mozilliansorg_cloudservices_aws_fxa_developers
     - mozilliansorg_cloudservices_aws_taskcluster_devs
     - mozilliansorg_infrasec
+    - mozilliansorg_meao-admins
     authorized_users: []
     client_id: c0x6EoLdp55H2g2OXZTIUuaQ4v8U4xf9
     display: true


### PR DESCRIPTION
`mozilliansorg_meao-admins` was only mapped to IT. With @bwells-moz's PR we'll need to ensure it's mapped to CloudServices' as well.

See also: https://github.com/mozilla/global-platform-admin/pull/5872

Jira: SVCSE-4371

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
