### PR TITLE
Pagerduty: display the tile and remove `everyone`

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -559,7 +559,6 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
-    - everyone
     authorized_users: []
     client_id: Gav1XmmrpBxts0zeDPOSfGesVrTt044k
     display: true

--- a/apps.yml
+++ b/apps.yml
@@ -562,7 +562,7 @@ apps:
     - everyone
     authorized_users: []
     client_id: Gav1XmmrpBxts0zeDPOSfGesVrTt044k
-    display: false
+    display: true
     logo: pagerduty.png
     name: PagerDuty
     op: auth0


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
