### PR TITLE
fix(claude): IdP-initiated login not supported

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -6122,6 +6122,20 @@ apps:
     - /claude-code
 - application:
     authorized_groups:
+    - mozilliansorg_claude_code-admin
+    - mozilliansorg_claude_cowork-access
+    - mozilliansorg_claude-owners
+    authorized_users: []
+    client_id: kO6jg7RGbIsZQUIV5zMDrQ0FdxknN96C
+    display: false
+    logo: auth0.png
+    name: Claude Cowork
+    op: auth0
+    url: https://claude.ai/login
+    vanity_url:
+    - /claude-cowork
+- application:
+    authorized_groups:
     - mozilliansorg_claude_code-access-mofo
     authorized_users: []
     client_id: coPeHai947noc9267KOhhHxbw709hccP

--- a/apps.yml
+++ b/apps.yml
@@ -6117,7 +6117,7 @@ apps:
     logo: claudecode.png
     name: Claude Code
     op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/kO6jg7RGbIsZQUIV5zMDrQ0FdxknN96C
+    url: https://platform.claude.com/login?returnTo=%2Fdashboard
     vanity_url:
     - /claude-code
 - application:


### PR DESCRIPTION
The flow has to be SP-initiated for now. This may be a little confusing for users, since on the SP login page, they give an additional login option, Google.

Jira: IAM-1970

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
