### PR TITLE
feat(apps): add internal ux tool

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -6392,3 +6392,13 @@ apps:
     name: Coursera Enterprise
     op: auth0
     url: https://www.coursera.org/?authMode=login&authProvider=mozilla
+- application:
+    authorized_groups:
+    - team_moco
+    authorized_users: []
+    client_id: RGGO05yKAcoI0akTTo8tvUpwUhaDZ8n1
+    display: false
+    logo: auth0.png
+    name: Internal UX Tool
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/RGGO05yKAcoI0akTTo8tvUpwUhaDZ8n1


### PR DESCRIPTION
Jira: IAM-1969

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

---

Note that the legal/security reviews _have not been done_ yet. This is for an internal-use-only app, running on the GCP sandbox.