### PR TITLE
IAM-1972: Add Statuspage - Tabstack

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -6412,3 +6412,13 @@ apps:
     name: AI scanner
     op: auth0
     url: https://auth.mozilla.auth0.com/samlp/sQyEohqxVmYnjn8qkIEkKFrKv1oCtAPl
+- application:
+    authorized_groups:
+    - mozilliansorg_statuspage-tabstack-access
+    authorized_users: []
+    client_id: 7RtDx8tcYipTaUuGJNhGgU4nH7tRZEii
+    display: true
+    logo: statuspage.png
+    name: Statuspage - Tabstack
+    op: auth0
+    url: https://manage.statuspage.io/sso/saml/consume


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/IAM-1972
https://people.mozilla.org/a/statuspage-tabstack-access/

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
