### PR TITLE
feat: Add Workato Identity

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -6469,3 +6469,15 @@ apps:
     url: https://auth.mozilla.auth0.com/samlp/nH4nrFIPvph6jxi6qwpKTlkREzdbbuNw
     vanity_url:
     - /avigilon
+- application:
+    authorized_groups:
+    - mozilliansorg_workato_user-end_user
+    authorized_users: []
+    client_id: qXfKerLoU8w8FN76OB9Yt7I6w2N8lD2Y
+    display: false
+    logo: auth0.png
+    name: Workato Identity
+    op: auth0
+    url: https://auth.mozilla.auth0.com/samlp/qXfKerLoU8w8FN76OB9Yt7I6w2N8lD2Y
+    vanity_url:
+    - /workato-identity


### PR DESCRIPTION
Turns out we need to split up our Workato apps. There's another one coming soon so we're able to keep all authnz active while the switch happens.

Jira: IAM-1957

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
