### PR TITLE
Cleanup exited users ; add Workato user [ITORG-200]

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -2156,9 +2156,7 @@ apps:
     - team_moco
     - team_mofo
     - team_mzla
-    authorized_users:
-    - dlipski@mozilla.com
-    - jeide@mozilla.com
+    authorized_users: []
     client_id: TB91RkOJc4eQhOuT0SIfUHm2nD6W3ipT
     display: true
     logo: coderpad.png

--- a/apps.yml
+++ b/apps.yml
@@ -437,7 +437,8 @@ apps:
     - team_office_support
     - service_jira
     - travelling_accounts_jira
-    authorized_users: []
+    authorized_users:
+    - workato-automation@mozilla.com
     client_id: TKqD0MP8sDeJAc9QC4f5yp2r9qbx5fcZ
     display: true
     logo: jira.png
@@ -463,6 +464,7 @@ apps:
     authorized_users:
     - moc+servicenow@mozilla.com
     - moc-sso-monitoring@mozilla.com
+    - workato-automation@mozilla.com
     client_id: TKqD0MP8sDeJAc9QC4f5yp2r9qbx5fcZ
     display: true
     logo: confluence.png
@@ -3660,7 +3662,8 @@ apps:
     - team_mozillaonline
     - travelling_accounts
     - team_office_support
-    authorized_users: []
+    authorized_users:
+    - workato-automation@mozilla.com
     client_id: htnpYVQ6jsBnxstKeETNerYgVUjvE7SB
     display: true
     logo: slack.png


### PR DESCRIPTION
Commit 1, a freebie-ridealong:  Removed two exited humans from `apps.yml`
Commit 2: Add `workato-automation@mozilla.com` - a nonhuman "LDAP shared_account" to Slack/Jira/Confluence.
This follows prior art (seen in the Confluence entry) of "using `authorized_users` instead of `authorized_groups` isn't great, but it should be fine for nonhumans / service accounts"