### PR TITLE
Add mozilla.org to airmo, IAM-1981

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -128,6 +128,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
+    - team_mozorg
     - team_mzla
     - team_mzai
     - team_mozillaonline


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
