### PR TITLE
chore(aws): Grant `sre` group access to AWS Cloudservices

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3594,6 +3594,7 @@ apps:
     - mozilliansorg_cloudservices_aws_taskcluster_devs
     - mozilliansorg_infrasec
     - mozilliansorg_meao-admins
+    - mozilliansorg_sre
     authorized_users: []
     client_id: c0x6EoLdp55H2g2OXZTIUuaQ4v8U4xf9
     display: true


### PR DESCRIPTION
This PR grants the `sre` group access to AWS Cloudservices. I'm amazed that I'm the first person to run into this missing - @tcotav only ran into it because it was his first day trying to do AWS stuff