### PR TITLE
Update balrog admin UI urls

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -1322,7 +1322,7 @@ apps:
     logo: balrog.png
     name: Balrog (Prod)
     op: auth0
-    url: https://balrog.services.mozilla.com
+    url: https://balrog.mozilla.org
 - application:
     authorized_groups:
     - team_services_ops
@@ -1333,7 +1333,7 @@ apps:
     logo: balrog.png
     name: Balrog (Stage)
     op: auth0
-    url: https://balrog-admin-static-stage.stage.mozaws.net/
+    url: https://balrog.allizom.org
 - application:
     authorized_groups:
     - team_moco


### PR DESCRIPTION
Matches the updated https://mozilla-balrog.readthedocs.io/en/latest/infrastructure.html#environments after the migration from gcpv1 to mozcloud.

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
