### PR TITLE
runlayer: enable for moco and mofo

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -6507,7 +6507,10 @@ apps:
     - /workato-workspace
 - application:
     authorized_groups:
+    - team_moco
+    - team_mofo
     - mozilliansorg_mozillm-admins
+    - mozilliansorg_mozillm-developers
     authorized_users: []
     client_id: AFdKegJUDbFabXhfyXnK6amrO8NpAuiE
     display: false


### PR DESCRIPTION
Jira: IAM-1986

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
