### PR TITLE
Make Coursera tile visible

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -6423,7 +6423,7 @@ apps:
     - /togetherai
 - application:
     authorized_groups:
-    - team_moco
+    - team_moco_benefited
     authorized_users: []
     client_id: IGrCw2oLP4ySxkqvyfdbNT7BFrJOyDGp
     display: true

--- a/apps.yml
+++ b/apps.yml
@@ -6426,7 +6426,7 @@ apps:
     - team_moco
     authorized_users: []
     client_id: IGrCw2oLP4ySxkqvyfdbNT7BFrJOyDGp
-    display: false
+    display: true
     logo: coursera.png
     name: Coursera Enterprise
     op: auth0


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
