### PR TITLE
IAM-2007: Remove LifeLabs

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3616,21 +3616,6 @@ apps:
     - /aws-cloudservices
 - application:
     authorized_groups:
-    - team_moco
-    - team_elance
-    - mozilliansorg_lifelabs-access
-    authorized_users: []
-    client_id: OWmWq6YwMvc8TwIrMlWzK81KaLZDkOYw
-    display: true
-    logo: lifelabs.png
-    name: LifeLabs Learning
-    op: auth0
-    url: https://app.lifelabslearning.com/training?sso=mozilla
-    vanity_url:
-    - /lifelabs
-    - /mlp
-- application:
-    authorized_groups:
     - mozilliansorg_azure-access
     authorized_users: []
     client_id: cg5g2Q48SzDjVHjqfmcXJIm8YTg40nTO


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

Confirmed with Allison that this is good to go.