### PR TITLE
yardstick: enable access for team_mzla

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -4006,6 +4006,7 @@ apps:
     authorized_groups:
     - team_moco
     - team_mofo
+    - team_mzla
     - mozilliansorg_obs_grafana_admin-access
     authorized_users: []
     client_id: rbH2lgiwsLN3A9QD9h4zv0mWtxP85UwE


### PR DESCRIPTION
SREIN-1536

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
