### PR TITLE
New group for crowdstrike

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -2904,6 +2904,7 @@ apps:
 - application:
     authorized_groups:
     - mozilliansorg_sec_endpoint_detection
+    - mozilliansorg_sec-siem-access
     authorized_users: []
     client_id: 0dlDsk4pkHQOk13M86WR6VvZFaIYBqI8
     display: true


### PR DESCRIPTION
Jira: [IAM-2024](https://mozilla-hub.atlassian.net/browse/IAM-2024)

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
