### PR TITLE
Cleanup of team_elance and Coursera groups fix

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -6411,6 +6411,8 @@ apps:
 - application:
     authorized_groups:
     - team_moco_benefited
+    - workertype_eor
+    - workertype_fixed_term
     authorized_users: []
     client_id: IGrCw2oLP4ySxkqvyfdbNT7BFrJOyDGp
     display: true

--- a/apps.yml
+++ b/apps.yml
@@ -2420,7 +2420,7 @@ apps:
     - team_moco_benefited
     - team_mofo
     - team_mozillaonline
-    - team_elance
+    - workertype_eor
     authorized_users: []
     client_id: w8hBBYB30b12DqElacIQkFM6V2deEpwz
     display: false


### PR DESCRIPTION
Mostly verbal, but some BIZSYS-1988 and IAM-1949.

Coursera missed getting all employees that should've been allowed in; half bad copyover from the Udemy decom, and half uncommunicated change in who was allowed.

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
