### PR TITLE
New access group for Runlayer

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -6511,6 +6511,7 @@ apps:
     - team_mofo
     - mozilliansorg_mozillm-admins
     - mozilliansorg_mozillm-developers
+    - mozilliansorg_runlayer-it-service-desk-access
     authorized_users: []
     client_id: AFdKegJUDbFabXhfyXnK6amrO8NpAuiE
     display: false


### PR DESCRIPTION
Jira: [IAM-2031](https://mozilla-hub.atlassian.net/browse/IAM-2031)

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
