### PR TITLE
Bedrock guardrail testing access

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -3262,6 +3262,7 @@ apps:
     authorized_groups:
     - fuzzing_team
     - mozilliansorg_0din-devs
+    - mozilliansorg_0din-guardrail-testing
     - mozilliansorg_aws_billing_access
     - mozilliansorg_cia-aws
     - mozilliansorg_consolidated-billing-aws


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

IAM -2020

Access to AWS Bedrock Guardrail testing.

https://github.com/mozilla-iam/auth0-deploy/pull/549
https://github.com/mozilla/global-platform-admin/pull/6848