### PR TITLE
feat: Add test RPs

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -6634,3 +6634,66 @@ apps:
     name: admin.prod.fx-sharing.prod.webservices.mozgcp.net
     op: auth0
     url: https://admin.prod.fx-sharing.prod.webservices.mozgcp.net/admin/
+- application:
+    AAL: HIGH
+    authorized_groups:
+    - team_moco
+    authorized_users: []
+    client_id: klvKlpIyTObobDMu1hP62TGW7cXOdcOp
+    display: false
+    logo: auth0.png
+    name: Test RP High AAL (dev)
+    op: auth0
+    url: https://oidc-aal-high.dev.iam.nonprod.webservices.mozgcp.net/
+- application:
+    authorized_groups:
+    - team_moco
+    authorized_users: []
+    client_id: iO7LBg2F72JWD8RHil7wZnvoSPJb75Cj
+    display: false
+    logo: auth0.png
+    name: Test RP Medium AAL (dev)
+    op: auth0
+    url: https://oidc-aal-medium.dev.iam.nonprod.webservices.mozgcp.net/
+- application:
+    AAL: HIGH
+    authorized_groups:
+    - team_moco
+    authorized_users: []
+    client_id: kwBVere8Ff6HozEzMK6uMblAgTRrcaUx
+    display: false
+    logo: auth0.png
+    name: Test RP High AAL (stage)
+    op: auth0
+    url: https://oidc-aal-high.stage.iam.nonprod.webservices.mozgcp.net/
+- application:
+    authorized_groups:
+    - team_moco
+    authorized_users: []
+    client_id: NbXEW3Ybo6uVHIaFWRAx25GLigL27gCP
+    display: false
+    logo: auth0.png
+    name: Test RP Medium AAL (stage)
+    op: auth0
+    url: https://oidc-aal-medium.stage.iam.nonprod.webservices.mozgcp.net/
+- application:
+    AAL: HIGH
+    authorized_groups:
+    - team_moco
+    authorized_users: []
+    client_id: 763s9P6S8HbQqH5H6EpbXrhUREfEXmjv
+    display: false
+    logo: auth0.png
+    name: Test RP High AAL
+    op: auth0
+    url: https://oidc-aal-high.prod.iam.prod.webservices.mozgcp.net/
+- application:
+    authorized_groups:
+    - team_moco
+    authorized_users: []
+    client_id: vI7mI0OioVmARr1mRIEYuYzl0q03TQO7
+    display: false
+    logo: auth0.png
+    name: Test RP Medium AAL
+    op: auth0
+    url: https://oidc-aal-medium.prod.iam.prod.webservices.mozgcp.net/

--- a/ci/resources/lint-apps-keep-client-ids.yml
+++ b/ci/resources/lint-apps-keep-client-ids.yml
@@ -13,3 +13,7 @@ fKFekrRsCA38RsjqRS6UpbLW8GOOh2wi:
     reason: Dev and Prod share an apps.yml file.
 yHBekJlXiWOPiZQL5N3aCcab8nwSUasl:
     reason: Dev and Prod share an apps.yml file.
+klvKlpIyTObobDMu1hP62TGW7cXOdcOp:
+    reason: Dev and Prod share an apps.yml file.
+iO7LBg2F72JWD8RHil7wZnvoSPJb75Cj:
+    reason: Dev and Prod share an apps.yml file.


### PR DESCRIPTION
I spun up some test RPs using authlib/auth-playground deployed to GCPv2. These give us a safe space to test apps with high assurance requirements.

Jira: IAM-1989

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
