### PR TITLE
Add HIGH AAL to list of accepted values

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,7 @@ name: Tests
 
 on:
   workflow_call:
+  pull_request:
 
 jobs:
   test:

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -30,7 +30,7 @@ class Application(TypedDict):
     authorized_groups: list[str]
     client_id: NotRequired[str]
     vanity_url: NotRequired[list[str]]
-    AAL: NotRequired[Literal["LOW", "MEDIUM", "MAXIMUM"]]
+    AAL: NotRequired[Literal["LOW", "MEDIUM", "HIGH", "MAXIMUM"]]
 
 class AppEntry(TypedDict):
     """An item in the `apps` list."""


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
