### PR TITLE
Added new workato workspace groups

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -6508,7 +6508,6 @@ apps:
     - mozilliansorg_workato_workspace_group-financesystems-viewonly
     - mozilliansorg_workato_workspace_group-financesystems-devs
     - mozilliansorg_workato_workspace_group-financesystems-admins
-
     authorized_users: []
     client_id: JmJAOmGbtZsojMpFQC5fcmqghWHbuKrf
     display: false

--- a/apps.yml
+++ b/apps.yml
@@ -6495,6 +6495,20 @@ apps:
     - mozilliansorg_workato_workspace_role-test
     - mozilliansorg_workato_workspace_role-prod
     - mozilliansorg_workato_workspace_group-mozilla-product-management
+    - mozilliansorg_workato_workspace_group-wptatomations-admins
+    - mozilliansorg_workato_workspace_group-servicedesk-viewonly
+    - mozilliansorg_workato_workspace_group-servicedesk-devs
+    - mozilliansorg_workato_workspace_group-servicedesk-admins
+    - mozilliansorg_workato_workspace_group-mozengineeringproduct-viewonly
+    - mozilliansorg_workato_workspace_group-mozengineeringproduct-devs
+    - mozilliansorg_workato_workspace_group-mozengineeringproduct-admins
+    - mozilliansorg_workato_workspace_group-hr-viewonly
+    - mozilliansorg_workato_workspace_group-hr-devs
+    - mozilliansorg_workato_workspace_group-hr-admins
+    - mozilliansorg_workato_workspace_group-financesystems-viewonly
+    - mozilliansorg_workato_workspace_group-financesystems-devs
+    - mozilliansorg_workato_workspace_group-financesystems-admins
+
     authorized_users: []
     client_id: JmJAOmGbtZsojMpFQC5fcmqghWHbuKrf
     display: false

--- a/apps.yml
+++ b/apps.yml
@@ -6495,7 +6495,7 @@ apps:
     - mozilliansorg_workato_workspace_role-test
     - mozilliansorg_workato_workspace_role-prod
     - mozilliansorg_workato_workspace_group-mozilla-product-management
-    - mozilliansorg_workato_workspace_group-wptatomations-admins
+    - mozilliansorg_workato_workspace_group-wptautomations-admins
     - mozilliansorg_workato_workspace_group-servicedesk-viewonly
     - mozilliansorg_workato_workspace_group-servicedesk-devs
     - mozilliansorg_workato_workspace_group-servicedesk-admins


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

IAM-2033: Adding new Workato workspace groups.
