### PR TITLE
removed culture amp for MoCo

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -2478,19 +2478,6 @@ apps:
     - /stripe-subplat
 - application:
     authorized_groups:
-    - team_moco
-    - team_mozillaonline
-    authorized_users: []
-    client_id: axRGaXPRd5pe60fnEllluSN76MefFX1E
-    display: true
-    logo: cultureamp.png
-    name: Culture Amp
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/axRGaXPRd5pe60fnEllluSN76MefFX1E
-    vanity_url:
-    - /cultureamp
-- application:
-    authorized_groups:
     - team_mofo
     authorized_users: []
     client_id: 4b1qHRbxLmNLEBgXMi5eYP0sJn5p6q7l


### PR DESCRIPTION
IAM-1907: removed Culture Amp now that we've fully migrated to Lattice.