### PR TITLE
Remove OReilly/Safaribooks, SER-1061

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -1693,17 +1693,6 @@ apps:
     url: https://lando.devsvcstage.mozaws.net/redirect_uri
 - application:
     authorized_groups:
-    - team_moco
-    - team_mofo
-    authorized_users: []
-    client_id: XMAlQpd3P8y34lZF2EvgdNkNxWIP3KD2
-    display: false
-    logo: auth0.png
-    name: Safari
-    op: auth0
-    url: https://safarijv.auth0.com/login/callback?connection=Mozilla
-- application:
-    authorized_groups:
     - mozilliansorg_stmo_nda
     - team_moco
     - team_mofo


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

This cleanup was missed in the 2020 timeframe.  Someone more qualified than me, can you do the auth0 scrub as part of this, please and thank you?