### PR TITLE
Remove ConsoleFlow

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -2173,17 +2173,6 @@ apps:
     op: auth0
     url: https://recit.getpocket.dev/login
 - application:
-    authorized_groups:
-    - team_netops
-    - team_infra
-    authorized_users: []
-    client_id: OSKMKPkvUoDg0K8agd4iHSwUam0lpr6p
-    display: false
-    logo: auth0.png
-    name: ConsoleFlow
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/OSKMKPkvUoDg0K8agd4iHSwUam0lpr6p
-- application:
     AAL: LOW
     authorized_groups:
     - everyone


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

Creation was [bug 1576983](https://bugzilla.mozilla.org/show_bug.cgi?id=1576983)
<johnb> :dividehex wasn't able to filter the groups down to the one needed so Lantronix would never give someone access consistently.  Only the few times the right group was the first in the list.

Please zap auth0, no rush on a deploy afterwards since it's just a cleanup.