### PR TITLE
Added Workato workspace groups

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -6503,11 +6503,16 @@ apps:
     - mozilliansorg_workato_workspace_group-mozengineeringproduct-devs
     - mozilliansorg_workato_workspace_group-mozengineeringproduct-admins
     - mozilliansorg_workato_workspace_group-hr-viewonly
-    - mozilliansorg_workato_workspace_group-hr-devs
+    - mozilliansorg_workato_workspace_group-hr-devsx
     - mozilliansorg_workato_workspace_group-hr-admins
     - mozilliansorg_workato_workspace_group-financesystems-viewonly
     - mozilliansorg_workato_workspace_group-financesystems-devs
     - mozilliansorg_workato_workspace_group-financesystems-admins
+    - workato_workspace_group-wptautomations-devs
+    - workato_workspace_group-wptautomations-viewonly
+    - workato_workspace_group-eam-admins
+    - workato_workspace_group-eam-devs
+    - workato_workspace_group-eam-viewonly
     authorized_users: []
     client_id: JmJAOmGbtZsojMpFQC5fcmqghWHbuKrf
     display: false

--- a/apps.yml
+++ b/apps.yml
@@ -6496,6 +6496,8 @@ apps:
     - mozilliansorg_workato_workspace_role-prod
     - mozilliansorg_workato_workspace_group-mozilla-product-management
     - mozilliansorg_workato_workspace_group-wptautomations-admins
+    - mozilliansorg_workato_workspace_group-wptautomations-devs
+    - workato_workspace_group-wptautomations-viewonly    
     - mozilliansorg_workato_workspace_group-servicedesk-viewonly
     - mozilliansorg_workato_workspace_group-servicedesk-devs
     - mozilliansorg_workato_workspace_group-servicedesk-admins
@@ -6503,16 +6505,14 @@ apps:
     - mozilliansorg_workato_workspace_group-mozengineeringproduct-devs
     - mozilliansorg_workato_workspace_group-mozengineeringproduct-admins
     - mozilliansorg_workato_workspace_group-hr-viewonly
-    - mozilliansorg_workato_workspace_group-hr-devsx
+    - mozilliansorg_workato_workspace_group-hr-devs
     - mozilliansorg_workato_workspace_group-hr-admins
     - mozilliansorg_workato_workspace_group-financesystems-viewonly
     - mozilliansorg_workato_workspace_group-financesystems-devs
     - mozilliansorg_workato_workspace_group-financesystems-admins
-    - workato_workspace_group-wptautomations-devs
-    - workato_workspace_group-wptautomations-viewonly
-    - workato_workspace_group-eam-admins
-    - workato_workspace_group-eam-devs
-    - workato_workspace_group-eam-viewonly
+    - mozilliansorg_workato_workspace_group-eam-admins
+    - mozilliansorg_workato_workspace_group-eam-devs
+    - mozilliansorg_workato_workspace_group-eam-viewonly
     authorized_users: []
     client_id: JmJAOmGbtZsojMpFQC5fcmqghWHbuKrf
     display: false

--- a/apps.yml
+++ b/apps.yml
@@ -6497,7 +6497,7 @@ apps:
     - mozilliansorg_workato_workspace_group-mozilla-product-management
     - mozilliansorg_workato_workspace_group-wptautomations-admins
     - mozilliansorg_workato_workspace_group-wptautomations-devs
-    - workato_workspace_group-wptautomations-viewonly    
+    - mozilliansorg_workato_workspace_group-wptautomations-viewonly    
     - mozilliansorg_workato_workspace_group-servicedesk-viewonly
     - mozilliansorg_workato_workspace_group-servicedesk-devs
     - mozilliansorg_workato_workspace_group-servicedesk-admins

--- a/apps.yml
+++ b/apps.yml
@@ -6497,7 +6497,7 @@ apps:
     - mozilliansorg_workato_workspace_group-mozilla-product-management
     - mozilliansorg_workato_workspace_group-wptautomations-admins
     - mozilliansorg_workato_workspace_group-wptautomations-devs
-    - mozilliansorg_workato_workspace_group-wptautomations-viewonly    
+    - mozilliansorg_workato_workspace_group-wptautomations-viewonly
     - mozilliansorg_workato_workspace_group-servicedesk-viewonly
     - mozilliansorg_workato_workspace_group-servicedesk-devs
     - mozilliansorg_workato_workspace_group-servicedesk-admins


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

IAM-2033 : Add Workato workspace groups