### PR TITLE
docs: Clarify what happens when an app specifies AAL but we require MFA

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -29,7 +29,15 @@
 #
 # 1. If the client_id is missing, MFA is not required. (This is uncommon.)
 #
-# 2. If `AAL: LOW` is present, MFA is not required. (This is uncommon.)
+# 2. If `AAL: LOW` is present, MFA is not required. (This is uncommon, but may
+#    occur with community focused apps, e.g. SSO Dashboard, PeopleMo, AirMo, etc.)
+#
+#    If someone from LDAP signs in _and_ they have Duo enabled, then we'll
+#    upgrade their permissions to MEDIUM (since 2FA is the weakest assurance
+#    we'll provide with Duo).
+#
+#    Unfortunately, even if a user uses a higher assurance authenticator when
+#    they've been upgraded (e.g. HIGH or MAXIMUM), we'll still say MEDIUM.
 #
 # 3. Otherwise, MFA is required.
 #


### PR DESCRIPTION
Spawned from https://github.com/mozilla-iam/auth0-deploy/pull/545#discussion_r3686213087.

Jira: [IAM-1989](https://mozilla-hub.atlassian.net/browse/IAM-1989)

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
