### PR TITLE
Remove the deprecated RP for surveymonkey

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -882,18 +882,6 @@ apps:
     - /zoom
 - application:
     authorized_groups:
-    - service_surveymonkey
-    authorized_users: []
-    client_id: LS57OeRbl164EPk39as1TQJ3QbiMuX5M
-    display: false
-    logo: auth0.png
-    name: SurveyMonkey
-    op: auth0
-    url: https://auth.mozilla.auth0.com/samlp/LS57OeRbl164EPk39as1TQJ3QbiMuX5M
-    vanity_url:
-    - /surveymonkey
-- application:
-    authorized_groups:
     - team_moco
     - team_mofo
     authorized_users: []


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

This RP is gated by a nearly-empty LDAP group, and https://mozilla-hub.atlassian.net/wiki/spaces/APPDEV/database/1610580330 lists it as a not-approved app, so this seeks to remove the RP.

Please clear out the auth0 app for it as well.   No need to force a deploy afterwards, it can ride-along with whatever the next deploy is.