### PR TITLE
Add GHE - mozilla-magnet

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -6209,6 +6209,17 @@ apps:
     url: https://sso.mozilla.com/
     logo: auth0.png
 - application:
+    AAL: LOW
+    authorized_groups:
+    - everyone
+    authorized_users: []
+    display: false
+    op: auth0
+    client_id: n99KHb8ymQS7nn9VyZ70JCxG5TwtbTVM
+    name: GitHub Enterprise - mozilla-magnet
+    url: https://sso.mozilla.com/
+    logo: auth0.png
+- application:
     authorized_groups:
     - mozilliansorg_sundial-access
     authorized_users: []


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

IO-3965