### PR TITLE
Provide access to Moco Greenhouse for MOFO shared account

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -391,7 +391,8 @@ apps:
     - team_mofo
     - team_mzla
     - team_mozorg
-    authorized_users: []
+    authorized_users:
+    - mofo-pnc-moco-gh@mozillafoundation.org
     client_id: TGlmvMW4kvEz99CRnuGnNTfxku0QNn8e
     display: true
     logo: greenhouse.png


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

Provide access to Moco Greenhouse for MOFO P&C team using a shared account.

https://mozilla-hub.atlassian.net/browse/IAM-2086