### PR TITLE
Make governance a bit easier

### DIFF
--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -95,3 +95,17 @@ class YAMLTest(unittest.TestCase):
                 assert len(vanity_urls_raw) > 0
                 for vanity_url_raw in vanity_urls_raw:
                     assert re.match(r'^/[-_A-Za-z0-9]+$', vanity_url_raw)
+
+    def test_each_app_has_one_aal(self):
+        apps = {}
+        yaml_content = get_yaml_file()
+        for app_entry in yaml_content['apps']:
+            app = app_entry['application']
+            client_id = app.get("client_id")
+            if client_id is None:
+                continue
+            aal = app.get("AAL", "MEDIUM")
+            if client_id not in apps:
+                apps[client_id] = aal
+                continue
+            assert apps[client_id] == aal, f"double AAL for same client id {client_id}"


### PR DESCRIPTION
The same app having different risk levels is sort of... annoying to keep track of.

Jira: IAM-1989

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
