### PR TITLE
Apps should be able to restrict MFA based on app+group

### DIFF
--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -31,6 +31,7 @@ class Application(TypedDict):
     client_id: NotRequired[str]
     vanity_url: NotRequired[list[str]]
     AAL: NotRequired[Literal["LOW", "MEDIUM", "HIGH", "MAXIMUM"]]
+    AAI: NotRequired[Literal["2FA", "HWK"]]
 
 class AppEntry(TypedDict):
     """An item in the `apps` list."""


### PR DESCRIPTION
Jira: IAM-1989

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
