### PR TITLE
Add Workato workspace group for CloudEngineering admins

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -6417,6 +6417,7 @@ apps:
     - mozilliansorg_workato_workspace_group-eam-admins
     - mozilliansorg_workato_workspace_group-eam-devs
     - mozilliansorg_workato_workspace_group-eam-viewonly
+    - mozilliansorg_workato_workspace_group-cloudengineering-admins
     authorized_users: []
     client_id: JmJAOmGbtZsojMpFQC5fcmqghWHbuKrf
     display: false


### PR DESCRIPTION
Add Workato workspace group for CloudEngineering admins

IAM-2092

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
