### PR TITLE
Revert "Temporarily support both LDAP and PMO groups"

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -2411,11 +2411,6 @@ apps:
     url: https://fxa-admin-panel.prod.mozaws.net/openid/callback/login
 - application:
     authorized_groups:
-    - stripe_subplat_admin
-    - stripe_subplat_analyst
-    - stripe_subplat_developer
-    - stripe_subplat_supportsp
-    - stripe_subplat_viewonly
     - mozilliansorg_stripe_subplat_admin
     - mozilliansorg_stripe_subplat_analyst
     - mozilliansorg_stripe_subplat_developer


### PR DESCRIPTION
This reverts commit 1d9b1276a00af56427a8098334b039cf39a076bd.

Jira: [IAM-2043](https://mozilla-hub.atlassian.net/browse/IAM-2043)

- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.
