### PR TITLE
Added MOFO group for greenhouse moco access (temp)

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -388,6 +388,7 @@ apps:
 - application:
     authorized_groups:
     - team_moco
+    - team_mofo
     - team_mzla
     - team_mozorg
     authorized_users:


### PR DESCRIPTION
- [x] All PRs are assigned to the review team automatically.
- [ ] **New integrations:** Legal _and_ Security reviews confirmed. `authorized_groups` and Auth0 `client_id` are defined. If `display: true`, the logo's image is attached. Auth0 app's Connections enables LDAP only.

IAM-2085: Greenhouse support team requested for a temporary access to Greenhouse Moco for MoFo users until Greenhouse MoFo SSO setup is complete.